### PR TITLE
Update locality names

### DIFF
--- a/data/101/791/007/101791007.geojson
+++ b/data/101/791/007/101791007.geojson
@@ -24,10 +24,9 @@
         "Nocrich"
     ],
     "name:eng_x_preferred":[
-        "Petre Luciu"
+        "Nocrich"
     ],
     "name:eng_x_variant":[
-        "Gara Petre Luciu",
         "Nocrich"
     ],
     "name:epo_x_preferred":[
@@ -62,9 +61,6 @@
     ],
     "name:ukr_x_preferred":[
         "\u041d\u043e\u043a\u0440\u0456\u0445"
-    ],
-    "name:unk_x_variant":[
-        "Petre Luciu"
     ],
     "name:vie_x_preferred":[
         "Nocrich"
@@ -118,7 +114,7 @@
     "wof:lang":[
         "rum"
     ],
-    "wof:lastmodified":1563575522,
+    "wof:lastmodified":1563993549,
     "wof:name":"Nocrich",
     "wof:parent_id":85687687,
     "wof:placetype":"locality",

--- a/data/101/795/999/101795999.geojson
+++ b/data/101/795/999/101795999.geojson
@@ -24,7 +24,7 @@
         "Piatra"
     ],
     "name:eng_x_variant":[
-        "Piatra"
+        "Petra"
     ],
     "name:fra_x_preferred":[
         "Piatra"
@@ -105,7 +105,7 @@
     "wof:lang":[
         "rum"
     ],
-    "wof:lastmodified":1563991850,
+    "wof:lastmodified":1564000526,
     "wof:name":"Piatra",
     "wof:parent_id":85687585,
     "wof:placetype":"locality",

--- a/data/101/795/999/101795999.geojson
+++ b/data/101/795/999/101795999.geojson
@@ -21,7 +21,7 @@
         "Piatra"
     ],
     "name:eng_x_preferred":[
-        "Petra"
+        "Piatra"
     ],
     "name:eng_x_variant":[
         "Piatra"
@@ -105,7 +105,7 @@
     "wof:lang":[
         "rum"
     ],
-    "wof:lastmodified":1563576441,
+    "wof:lastmodified":1563991850,
     "wof:name":"Piatra",
     "wof:parent_id":85687585,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1676
Also fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1678

Updated preferred and variant names for Piatra, Romania.

No PIP required, can merge once approved.