### PR TITLE
New neighbourhood records

### DIFF
--- a/data/144/483/852/5/1444838525.geojson
+++ b/data/144/483/852/5/1444838525.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838525,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"23.5885119977,46.7698671074,23.5885119977,46.7698671074",
+    "geom:latitude":46.769867,
+    "geom:longitude":23.588512,
+    "iso:country":"RO",
+    "lbl:latitude":46.769867,
+    "lbl:longitude":23.588512,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Centru"
+    ],
+    "name:ron_x_preferred":[
+        "Centru"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"f7184110f59deab0342cfcc2639f984a",
+    "wof:hierarchy":[],
+    "wof:id":1444838525,
+    "wof:lastmodified":1566335355,
+    "wof:name":"Centru",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    23.58851199767632,
+    46.76986710739443,
+    23.58851199767632,
+    46.76986710739443
+],
+  "geometry": {"coordinates":[23.58851199767632,46.76986710739443],"type":"Point"}
+}

--- a/data/144/483/852/5/1444838525.geojson
+++ b/data/144/483/852/5/1444838525.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101752019,
+        85633745,
+        85687727
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
     "wof:geomhash":"f7184110f59deab0342cfcc2639f984a",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101752019,
+            "neighbourhood_id":1444838525,
+            "region_id":85687727
+        }
+    ],
     "wof:id":1444838525,
-    "wof:lastmodified":1566335355,
+    "wof:lastmodified":1566339132,
     "wof:name":"Centru",
-    "wof:parent_id":-1,
+    "wof:parent_id":101752019,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],

--- a/data/144/483/853/3/1444838533.geojson
+++ b/data/144/483/853/3/1444838533.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101752019,
+        85633745,
+        85687727
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
-    "wof:geomhash":"5cb8299a67ed042f64b32e5f60e0360a",
-    "wof:hierarchy":[],
+    "wof:geomhash":"2cdde669a53434aee5da25e66063ef0d",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101752019,
+            "neighbourhood_id":1444838533,
+            "region_id":85687727
+        }
+    ],
     "wof:id":1444838533,
-    "wof:lastmodified":1566335355,
+    "wof:lastmodified":1566339133,
     "wof:name":"Marasti",
-    "wof:parent_id":-1,
+    "wof:parent_id":101752019,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    23.612716264005133,
+    23.61271626400513,
     46.78150588876083,
-    23.612716264005133,
+    23.61271626400513,
     46.78150588876083
 ],
   "geometry": {"coordinates":[23.61271626400513,46.78150588876083],"type":"Point"}

--- a/data/144/483/853/3/1444838533.geojson
+++ b/data/144/483/853/3/1444838533.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838533,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"23.612716264,46.7815058888,23.612716264,46.7815058888",
+    "geom:latitude":46.781506,
+    "geom:longitude":23.612716,
+    "iso:country":"RO",
+    "lbl:latitude":46.781506,
+    "lbl:longitude":23.612716,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Marasti"
+    ],
+    "name:ron_x_preferred":[
+        "M\u0103r\u0103\u0219ti"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"5cb8299a67ed042f64b32e5f60e0360a",
+    "wof:hierarchy":[],
+    "wof:id":1444838533,
+    "wof:lastmodified":1566335355,
+    "wof:name":"Marasti",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    23.612716264005133,
+    46.78150588876083,
+    23.612716264005133,
+    46.78150588876083
+],
+  "geometry": {"coordinates":[23.61271626400513,46.78150588876083],"type":"Point"}
+}

--- a/data/144/483/854/1/1444838541.geojson
+++ b/data/144/483/854/1/1444838541.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838541,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"23.5694575752,46.7862077132,23.5694575752,46.7862077132",
+    "geom:latitude":46.786208,
+    "geom:longitude":23.569458,
+    "iso:country":"RO",
+    "lbl:latitude":46.786208,
+    "lbl:longitude":23.569457,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Dambul Rotund"
+    ],
+    "name:ron_x_preferred":[
+        "D\u00e2mbul Rotund"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"9af70f96ea24f49390d90d69b835759f",
+    "wof:hierarchy":[],
+    "wof:id":1444838541,
+    "wof:lastmodified":1566335355,
+    "wof:name":"Dambul Rotund",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    23.569457575247256,
+    46.78620771317727,
+    23.569457575247256,
+    46.78620771317727
+],
+  "geometry": {"coordinates":[23.56945757524726,46.78620771317727],"type":"Point"}
+}

--- a/data/144/483/854/1/1444838541.geojson
+++ b/data/144/483/854/1/1444838541.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101752019,
+        85633745,
+        85687727
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
-    "wof:geomhash":"9af70f96ea24f49390d90d69b835759f",
-    "wof:hierarchy":[],
+    "wof:geomhash":"c2b6091990e9ffa2728b0be96926791b",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101752019,
+            "neighbourhood_id":1444838541,
+            "region_id":85687727
+        }
+    ],
     "wof:id":1444838541,
-    "wof:lastmodified":1566335355,
+    "wof:lastmodified":1566339136,
     "wof:name":"Dambul Rotund",
-    "wof:parent_id":-1,
+    "wof:parent_id":101752019,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    23.569457575247256,
+    23.56945757524726,
     46.78620771317727,
-    23.569457575247256,
+    23.56945757524726,
     46.78620771317727
 ],
   "geometry": {"coordinates":[23.56945757524726,46.78620771317727],"type":"Point"}

--- a/data/144/483/855/9/1444838559.geojson
+++ b/data/144/483/855/9/1444838559.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838559,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"23.5560679811,46.7542860161,23.5560679811,46.7542860161",
+    "geom:latitude":46.754286,
+    "geom:longitude":23.556068,
+    "iso:country":"RO",
+    "lbl:latitude":46.754286,
+    "lbl:longitude":23.556068,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Manastur"
+    ],
+    "name:ron_x_preferred":[
+        "M\u0103n\u0103\u0219tur"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"e20869f8c6955a0d5068eacfd37b67df",
+    "wof:hierarchy":[],
+    "wof:id":1444838559,
+    "wof:lastmodified":1566335355,
+    "wof:name":"Manastur",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    23.556067981107912,
+    46.75428601611341,
+    23.556067981107912,
+    46.75428601611341
+],
+  "geometry": {"coordinates":[23.55606798110791,46.75428601611341],"type":"Point"}
+}

--- a/data/144/483/855/9/1444838559.geojson
+++ b/data/144/483/855/9/1444838559.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101752019,
+        85633745,
+        85687727
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
-    "wof:geomhash":"e20869f8c6955a0d5068eacfd37b67df",
-    "wof:hierarchy":[],
+    "wof:geomhash":"9f9040276f6e211aa7f18caa00c12cbf",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101752019,
+            "neighbourhood_id":1444838559,
+            "region_id":85687727
+        }
+    ],
     "wof:id":1444838559,
-    "wof:lastmodified":1566335355,
+    "wof:lastmodified":1566339136,
     "wof:name":"Manastur",
-    "wof:parent_id":-1,
+    "wof:parent_id":101752019,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    23.556067981107912,
+    23.55606798110791,
     46.75428601611341,
-    23.556067981107912,
+    23.55606798110791,
     46.75428601611341
 ],
   "geometry": {"coordinates":[23.55606798110791,46.75428601611341],"type":"Point"}

--- a/data/144/483/856/7/1444838567.geojson
+++ b/data/144/483/856/7/1444838567.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101752019,
+        85633745,
+        85687727
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
-    "wof:geomhash":"caf5c8fa6ab9e95a33ea2fc532256d77",
-    "wof:hierarchy":[],
+    "wof:geomhash":"a6a21ce6a419456456ef48ff8ca7b272",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101752019,
+            "neighbourhood_id":1444838567,
+            "region_id":85687727
+        }
+    ],
     "wof:id":1444838567,
-    "wof:lastmodified":1566335355,
+    "wof:lastmodified":1566339137,
     "wof:name":"Zorilor",
-    "wof:parent_id":-1,
+    "wof:parent_id":101752019,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],
@@ -46,9 +59,9 @@
 },
   "bbox": [
     23.58679538304307,
-    46.756461757383605,
+    46.7564617573836,
     23.58679538304307,
-    46.756461757383605
+    46.7564617573836
 ],
   "geometry": {"coordinates":[23.58679538304307,46.7564617573836],"type":"Point"}
 }

--- a/data/144/483/856/7/1444838567.geojson
+++ b/data/144/483/856/7/1444838567.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838567,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"23.586795383,46.7564617574,23.586795383,46.7564617574",
+    "geom:latitude":46.756462,
+    "geom:longitude":23.586795,
+    "iso:country":"RO",
+    "lbl:latitude":46.756462,
+    "lbl:longitude":23.586795,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Zorilor"
+    ],
+    "name:ron_x_preferred":[
+        "Zorilor"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"caf5c8fa6ab9e95a33ea2fc532256d77",
+    "wof:hierarchy":[],
+    "wof:id":1444838567,
+    "wof:lastmodified":1566335355,
+    "wof:name":"Zorilor",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    23.58679538304307,
+    46.756461757383605,
+    23.58679538304307,
+    46.756461757383605
+],
+  "geometry": {"coordinates":[23.58679538304307,46.7564617573836],"type":"Point"}
+}

--- a/data/144/483/857/5/1444838575.geojson
+++ b/data/144/483/857/5/1444838575.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101752019,
+        85633745,
+        85687727
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
-    "wof:geomhash":"fa1e7433781ff572482b6d8cc852e9ed",
-    "wof:hierarchy":[],
+    "wof:geomhash":"069b930f153fcaa76769eeeb1f6d5124",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101752019,
+            "neighbourhood_id":1444838575,
+            "region_id":85687727
+        }
+    ],
     "wof:id":1444838575,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339138,
     "wof:name":"Gheorgheni",
-    "wof:parent_id":-1,
+    "wof:parent_id":101752019,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    23.618552753758177,
+    23.61855275375818,
     46.76769190146856,
-    23.618552753758177,
+    23.61855275375818,
     46.76769190146856
 ],
   "geometry": {"coordinates":[23.61855275375818,46.76769190146856],"type":"Point"}

--- a/data/144/483/857/5/1444838575.geojson
+++ b/data/144/483/857/5/1444838575.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838575,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"23.6185527538,46.7676919015,23.6185527538,46.7676919015",
+    "geom:latitude":46.767692,
+    "geom:longitude":23.618553,
+    "iso:country":"RO",
+    "lbl:latitude":46.767692,
+    "lbl:longitude":23.618553,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Gheorgheni"
+    ],
+    "name:ron_x_preferred":[
+        "Gheorgheni"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"fa1e7433781ff572482b6d8cc852e9ed",
+    "wof:hierarchy":[],
+    "wof:id":1444838575,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Gheorgheni",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    23.618552753758177,
+    46.76769190146856,
+    23.618552753758177,
+    46.76769190146856
+],
+  "geometry": {"coordinates":[23.61855275375818,46.76769190146856],"type":"Point"}
+}

--- a/data/144/483/859/3/1444838593.geojson
+++ b/data/144/483/859/3/1444838593.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838593,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"23.6060214669,46.7626356886,23.6060214669,46.7626356886",
+    "geom:latitude":46.762636,
+    "geom:longitude":23.606021,
+    "iso:country":"RO",
+    "lbl:latitude":46.762636,
+    "lbl:longitude":23.606021,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Andrei Muresanu"
+    ],
+    "name:ron_x_preferred":[
+        "Andrei Mure\u0219anu"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"55d150c7689d02adce186a07bba29397",
+    "wof:hierarchy":[],
+    "wof:id":1444838593,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Andrei Muresanu",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    23.606021466935463,
+    46.76263568860821,
+    23.606021466935463,
+    46.76263568860821
+],
+  "geometry": {"coordinates":[23.60602146693546,46.76263568860821],"type":"Point"}
+}

--- a/data/144/483/859/3/1444838593.geojson
+++ b/data/144/483/859/3/1444838593.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101752019,
+        85633745,
+        85687727
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
-    "wof:geomhash":"55d150c7689d02adce186a07bba29397",
-    "wof:hierarchy":[],
+    "wof:geomhash":"2a309dc133f85587cfa5f676e6e04c98",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101752019,
+            "neighbourhood_id":1444838593,
+            "region_id":85687727
+        }
+    ],
     "wof:id":1444838593,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339141,
     "wof:name":"Andrei Muresanu",
-    "wof:parent_id":-1,
+    "wof:parent_id":101752019,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    23.606021466935463,
+    23.60602146693546,
     46.76263568860821,
-    23.606021466935463,
+    23.60602146693546,
     46.76263568860821
 ],
   "geometry": {"coordinates":[23.60602146693546,46.76263568860821],"type":"Point"}

--- a/data/144/483/859/7/1444838597.geojson
+++ b/data/144/483/859/7/1444838597.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101752019,
+        85633745,
+        85687727
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
-    "wof:geomhash":"cd9da8a8b664ff917ab3de6dd17bc48b",
-    "wof:hierarchy":[],
+    "wof:geomhash":"13431dd19348704706a492849095b847",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101752019,
+            "neighbourhood_id":1444838597,
+            "region_id":85687727
+        }
+    ],
     "wof:id":1444838597,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339141,
     "wof:name":"Gruia",
-    "wof:parent_id":-1,
+    "wof:parent_id":101752019,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    23.578898955730132,
+    23.57889895573013,
     46.77827314626523,
-    23.578898955730132,
+    23.57889895573013,
     46.77827314626523
 ],
   "geometry": {"coordinates":[23.57889895573013,46.77827314626523],"type":"Point"}

--- a/data/144/483/859/7/1444838597.geojson
+++ b/data/144/483/859/7/1444838597.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838597,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"23.5788989557,46.7782731463,23.5788989557,46.7782731463",
+    "geom:latitude":46.778273,
+    "geom:longitude":23.578899,
+    "iso:country":"RO",
+    "lbl:latitude":46.778273,
+    "lbl:longitude":23.578899,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Gruia"
+    ],
+    "name:ron_x_preferred":[
+        "Gruia"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"cd9da8a8b664ff917ab3de6dd17bc48b",
+    "wof:hierarchy":[],
+    "wof:id":1444838597,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Gruia",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    23.578898955730132,
+    46.77827314626523,
+    23.578898955730132,
+    46.77827314626523
+],
+  "geometry": {"coordinates":[23.57889895573013,46.77827314626523],"type":"Point"}
+}

--- a/data/144/483/860/9/1444838609.geojson
+++ b/data/144/483/860/9/1444838609.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101752019,
+        85633745,
+        85687727
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
-    "wof:geomhash":"44a73766b80dab8d2ca7e4b36dba592f",
-    "wof:hierarchy":[],
+    "wof:geomhash":"b1b24c513dbe2d3ddacadfbeaa1b21e2",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101752019,
+            "neighbourhood_id":1444838609,
+            "region_id":85687727
+        }
+    ],
     "wof:id":1444838609,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339142,
     "wof:name":"Intre Lacuri",
-    "wof:parent_id":-1,
+    "wof:parent_id":101752019,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    23.627822472777723,
+    23.62782247277772,
     46.77686243214522,
-    23.627822472777723,
+    23.62782247277772,
     46.77686243214522
 ],
   "geometry": {"coordinates":[23.62782247277772,46.77686243214522],"type":"Point"}

--- a/data/144/483/860/9/1444838609.geojson
+++ b/data/144/483/860/9/1444838609.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838609,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"23.6278224728,46.7768624321,23.6278224728,46.7768624321",
+    "geom:latitude":46.776862,
+    "geom:longitude":23.627822,
+    "iso:country":"RO",
+    "lbl:latitude":46.776862,
+    "lbl:longitude":23.627822,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Intre Lacuri"
+    ],
+    "name:ron_x_preferred":[
+        "\u00centre Lacuri"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"44a73766b80dab8d2ca7e4b36dba592f",
+    "wof:hierarchy":[],
+    "wof:id":1444838609,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Intre Lacuri",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    23.627822472777723,
+    46.77686243214522,
+    23.627822472777723,
+    46.77686243214522
+],
+  "geometry": {"coordinates":[23.62782247277772,46.77686243214522],"type":"Point"}
+}

--- a/data/144/483/861/7/1444838617.geojson
+++ b/data/144/483/861/7/1444838617.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101752019,
+        85633745,
+        85687727
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
     "wof:geomhash":"c79b1590aad56ef21a705c54fb207c26",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101752019,
+            "neighbourhood_id":1444838617,
+            "region_id":85687727
+        }
+    ],
     "wof:id":1444838617,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339143,
     "wof:name":"Bulgaria",
-    "wof:parent_id":-1,
+    "wof:parent_id":101752019,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],

--- a/data/144/483/861/7/1444838617.geojson
+++ b/data/144/483/861/7/1444838617.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838617,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"23.6212993372,46.7887935416,23.6212993372,46.7887935416",
+    "geom:latitude":46.788794,
+    "geom:longitude":23.621299,
+    "iso:country":"RO",
+    "lbl:latitude":46.788793,
+    "lbl:longitude":23.621299,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Bulgaria"
+    ],
+    "name:ron_x_preferred":[
+        "Bulgaria"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"c79b1590aad56ef21a705c54fb207c26",
+    "wof:hierarchy":[],
+    "wof:id":1444838617,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Bulgaria",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    23.62129933717138,
+    46.78879354156792,
+    23.62129933717138,
+    46.78879354156792
+],
+  "geometry": {"coordinates":[23.62129933717138,46.78879354156792],"type":"Point"}
+}

--- a/data/144/483/862/7/1444838627.geojson
+++ b/data/144/483/862/7/1444838627.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101752019,
+        85633745,
+        85687727
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
     "wof:geomhash":"72afd4f610a96c2565522e0e26fceee0",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101752019,
+            "neighbourhood_id":1444838627,
+            "region_id":85687727
+        }
+    ],
     "wof:id":1444838627,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339146,
     "wof:name":"Iris",
-    "wof:parent_id":-1,
+    "wof:parent_id":101752019,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],

--- a/data/144/483/862/7/1444838627.geojson
+++ b/data/144/483/862/7/1444838627.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838627,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"23.6063647899,46.7952575674,23.6063647899,46.7952575674",
+    "geom:latitude":46.795258,
+    "geom:longitude":23.606365,
+    "iso:country":"RO",
+    "lbl:latitude":46.795257,
+    "lbl:longitude":23.606365,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Iris"
+    ],
+    "name:ron_x_preferred":[
+        "Iris"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"72afd4f610a96c2565522e0e26fceee0",
+    "wof:hierarchy":[],
+    "wof:id":1444838627,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Iris",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    23.60636478986211,
+    46.79525756741579,
+    23.60636478986211,
+    46.79525756741579
+],
+  "geometry": {"coordinates":[23.60636478986211,46.79525756741579],"type":"Point"}
+}

--- a/data/144/483/863/9/1444838639.geojson
+++ b/data/144/483/863/9/1444838639.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838639,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"23.5575271035,46.7701904397,23.5575271035,46.7701904397",
+    "geom:latitude":46.77019,
+    "geom:longitude":23.557527,
+    "iso:country":"RO",
+    "lbl:latitude":46.77019,
+    "lbl:longitude":23.557527,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Grigorescu"
+    ],
+    "name:ron_x_preferred":[
+        "Grigorescu"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"d39590174a12197b6c9a940387d89871",
+    "wof:hierarchy":[],
+    "wof:id":1444838639,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Grigorescu",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    23.55752710354618,
+    46.77019043968933,
+    23.55752710354618,
+    46.77019043968933
+],
+  "geometry": {"coordinates":[23.55752710354618,46.77019043968933],"type":"Point"}
+}

--- a/data/144/483/863/9/1444838639.geojson
+++ b/data/144/483/863/9/1444838639.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101752019,
+        85633745,
+        85687727
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
     "wof:geomhash":"d39590174a12197b6c9a940387d89871",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101752019,
+            "neighbourhood_id":1444838639,
+            "region_id":85687727
+        }
+    ],
     "wof:id":1444838639,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339146,
     "wof:name":"Grigorescu",
-    "wof:parent_id":-1,
+    "wof:parent_id":101752019,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],

--- a/data/144/483/864/7/1444838647.geojson
+++ b/data/144/483/864/7/1444838647.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101752019,
+        85633745,
+        85687727
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
     "wof:geomhash":"20acea865289f460958b144d205ba6b3",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101752019,
+            "neighbourhood_id":1444838647,
+            "region_id":85687727
+        }
+    ],
     "wof:id":1444838647,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339147,
     "wof:name":"Buna Ziua",
-    "wof:parent_id":-1,
+    "wof:parent_id":101752019,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],

--- a/data/144/483/864/7/1444838647.geojson
+++ b/data/144/483/864/7/1444838647.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838647,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"23.5971809016,46.7486404307,23.5971809016,46.7486404307",
+    "geom:latitude":46.74864,
+    "geom:longitude":23.597181,
+    "iso:country":"RO",
+    "lbl:latitude":46.74864,
+    "lbl:longitude":23.597181,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Buna Ziua"
+    ],
+    "name:ron_x_preferred":[
+        "Bun\u0103 Ziua"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"20acea865289f460958b144d205ba6b3",
+    "wof:hierarchy":[],
+    "wof:id":1444838647,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Buna Ziua",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    23.59718090157423,
+    46.74864043066174,
+    23.59718090157423,
+    46.74864043066174
+],
+  "geometry": {"coordinates":[23.59718090157423,46.74864043066174],"type":"Point"}
+}

--- a/data/144/483/865/5/1444838655.geojson
+++ b/data/144/483/865/5/1444838655.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101752019,
+        85633745,
+        85687727
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
-    "wof:geomhash":"64410e098ff625829215c35b944eff9f",
-    "wof:hierarchy":[],
+    "wof:geomhash":"7cff5b30920848b7d06f29c807ba4c02",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101752019,
+            "neighbourhood_id":1444838655,
+            "region_id":85687727
+        }
+    ],
     "wof:id":1444838655,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339148,
     "wof:name":"Gradini Manastur",
-    "wof:parent_id":-1,
+    "wof:parent_id":101752019,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    23.565595192322434,
+    23.56559519232243,
     46.76322364508878,
-    23.565595192322434,
+    23.56559519232243,
     46.76322364508878
 ],
   "geometry": {"coordinates":[23.56559519232243,46.76322364508878],"type":"Point"}

--- a/data/144/483/865/5/1444838655.geojson
+++ b/data/144/483/865/5/1444838655.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838655,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"23.5655951923,46.7632236451,23.5655951923,46.7632236451",
+    "geom:latitude":46.763224,
+    "geom:longitude":23.565595,
+    "iso:country":"RO",
+    "lbl:latitude":46.763224,
+    "lbl:longitude":23.565595,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Gradini Manastur"
+    ],
+    "name:ron_x_preferred":[
+        "Gr\u0103dini M\u0103n\u0103\u0219tur"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"64410e098ff625829215c35b944eff9f",
+    "wof:hierarchy":[],
+    "wof:id":1444838655,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Gradini Manastur",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    23.565595192322434,
+    46.76322364508878,
+    23.565595192322434,
+    46.76322364508878
+],
+  "geometry": {"coordinates":[23.56559519232243,46.76322364508878],"type":"Point"}
+}

--- a/data/144/483/866/7/1444838667.geojson
+++ b/data/144/483/866/7/1444838667.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838667,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"23.5831904923,46.7465231844,23.5831904923,46.7465231844",
+    "geom:latitude":46.746523,
+    "geom:longitude":23.58319,
+    "iso:country":"RO",
+    "lbl:latitude":46.746523,
+    "lbl:longitude":23.58319,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Zorilor Sud"
+    ],
+    "name:ron_x_preferred":[
+        "Zorilor Sud"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"0ba6c63872cb80ffbdfa4b7a3752aef0",
+    "wof:hierarchy":[],
+    "wof:id":1444838667,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Zorilor Sud",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    23.58319049231324,
+    46.7465231844108,
+    23.58319049231324,
+    46.7465231844108
+],
+  "geometry": {"coordinates":[23.58319049231324,46.7465231844108],"type":"Point"}
+}

--- a/data/144/483/866/7/1444838667.geojson
+++ b/data/144/483/866/7/1444838667.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101752019,
+        85633745,
+        85687727
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
     "wof:geomhash":"0ba6c63872cb80ffbdfa4b7a3752aef0",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101752019,
+            "neighbourhood_id":1444838667,
+            "region_id":85687727
+        }
+    ],
     "wof:id":1444838667,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339151,
     "wof:name":"Zorilor Sud",
-    "wof:parent_id":-1,
+    "wof:parent_id":101752019,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],

--- a/data/144/483/867/3/1444838673.geojson
+++ b/data/144/483/867/3/1444838673.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838673,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"23.6044765138,46.8095344416,23.6044765138,46.8095344416",
+    "geom:latitude":46.809534,
+    "geom:longitude":23.604477,
+    "iso:country":"RO",
+    "lbl:latitude":46.809534,
+    "lbl:longitude":23.604477,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Valea Chintaului"
+    ],
+    "name:ron_x_preferred":[
+        "Valea Chint\u0103ului"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"01f0e1b69145fee90ffb131a77709355",
+    "wof:hierarchy":[],
+    "wof:id":1444838673,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Valea Chintaului",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    23.604476513765533,
+    46.809534441634185,
+    23.604476513765533,
+    46.809534441634185
+],
+  "geometry": {"coordinates":[23.60447651376553,46.80953444163418],"type":"Point"}
+}

--- a/data/144/483/867/3/1444838673.geojson
+++ b/data/144/483/867/3/1444838673.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101752019,
+        85633745,
+        85687727
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
-    "wof:geomhash":"01f0e1b69145fee90ffb131a77709355",
-    "wof:hierarchy":[],
+    "wof:geomhash":"8c8a16473f07e4456257661c3a9be831",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101752019,
+            "neighbourhood_id":1444838673,
+            "region_id":85687727
+        }
+    ],
     "wof:id":1444838673,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339152,
     "wof:name":"Valea Chintaului",
-    "wof:parent_id":-1,
+    "wof:parent_id":101752019,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],
@@ -45,10 +58,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    23.604476513765533,
-    46.809534441634185,
-    23.604476513765533,
-    46.809534441634185
+    23.60447651376553,
+    46.80953444163418,
+    23.60447651376553,
+    46.80953444163418
 ],
   "geometry": {"coordinates":[23.60447651376553,46.80953444163418],"type":"Point"}
 }

--- a/data/144/483/868/7/1444838687.geojson
+++ b/data/144/483/868/7/1444838687.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101752019,
+        85633745,
+        85687727
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
     "wof:geomhash":"083cb04bbeeebb305915798ca856bbd4",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101752019,
+            "neighbourhood_id":1444838687,
+            "region_id":85687727
+        }
+    ],
     "wof:id":1444838687,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339152,
     "wof:name":"Aurel Vlaicu",
-    "wof:parent_id":-1,
+    "wof:parent_id":101752019,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],

--- a/data/144/483/868/7/1444838687.geojson
+++ b/data/144/483/868/7/1444838687.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444838687,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"23.6326289938,46.7814177262,23.6326289938,46.7814177262",
+    "geom:latitude":46.781418,
+    "geom:longitude":23.632629,
+    "iso:country":"RO",
+    "lbl:latitude":46.781418,
+    "lbl:longitude":23.632629,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Aurel Vlaicu"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"083cb04bbeeebb305915798ca856bbd4",
+    "wof:hierarchy":[],
+    "wof:id":1444838687,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Aurel Vlaicu",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    23.63262899375082,
+    46.78141772620848,
+    23.63262899375082,
+    46.78141772620848
+],
+  "geometry": {"coordinates":[23.63262899375082,46.78141772620848],"type":"Point"}
+}

--- a/data/144/483/869/1/1444838691.geojson
+++ b/data/144/483/869/1/1444838691.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838691,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"23.6103130035,46.7544918315,23.6103130035,46.7544918315",
+    "geom:latitude":46.754492,
+    "geom:longitude":23.610313,
+    "iso:country":"RO",
+    "lbl:latitude":46.754492,
+    "lbl:longitude":23.610313,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Becas"
+    ],
+    "name:ron_x_preferred":[
+        "Beca\u0219"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"9ecf22b6b7f5a8c3c98a75a6ae4a9f7a",
+    "wof:hierarchy":[],
+    "wof:id":1444838691,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Becas",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    23.61031300351858,
+    46.75449183148142,
+    23.61031300351858,
+    46.75449183148142
+],
+  "geometry": {"coordinates":[23.61031300351858,46.75449183148142],"type":"Point"}
+}

--- a/data/144/483/869/1/1444838691.geojson
+++ b/data/144/483/869/1/1444838691.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101752019,
+        85633745,
+        85687727
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
     "wof:geomhash":"9ecf22b6b7f5a8c3c98a75a6ae4a9f7a",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101752019,
+            "neighbourhood_id":1444838691,
+            "region_id":85687727
+        }
+    ],
     "wof:id":1444838691,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339153,
     "wof:name":"Becas",
-    "wof:parent_id":-1,
+    "wof:parent_id":101752019,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],

--- a/data/144/483/870/1/1444838701.geojson
+++ b/data/144/483/870/1/1444838701.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838701,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"21.2296689148,45.7420871557,21.2296689148,45.7420871557",
+    "geom:latitude":45.742087,
+    "geom:longitude":21.229669,
+    "iso:country":"RO",
+    "lbl:latitude":45.742087,
+    "lbl:longitude":21.229669,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Elisabetin"
+    ],
+    "name:ron_x_preferred":[
+        "Elisabetin"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"468293420d4c4fd35ed76b770117521e",
+    "wof:hierarchy":[],
+    "wof:id":1444838701,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Elisabetin",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    21.22966891476208,
+    45.742087155718266,
+    21.22966891476208,
+    45.742087155718266
+],
+  "geometry": {"coordinates":[21.22966891476208,45.74208715571827],"type":"Point"}
+}

--- a/data/144/483/870/1/1444838701.geojson
+++ b/data/144/483/870/1/1444838701.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751973,
+        85633745,
+        85687655
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
-    "wof:geomhash":"468293420d4c4fd35ed76b770117521e",
-    "wof:hierarchy":[],
+    "wof:geomhash":"c0605ccf452e95af21ff557b0ac7ee09",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101751973,
+            "neighbourhood_id":1444838701,
+            "region_id":85687655
+        }
+    ],
     "wof:id":1444838701,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339156,
     "wof:name":"Elisabetin",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751973,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],
@@ -46,9 +59,9 @@
 },
   "bbox": [
     21.22966891476208,
-    45.742087155718266,
+    45.74208715571827,
     21.22966891476208,
-    45.742087155718266
+    45.74208715571827
 ],
   "geometry": {"coordinates":[21.22966891476208,45.74208715571827],"type":"Point"}
 }

--- a/data/144/483/870/7/1444838707.geojson
+++ b/data/144/483/870/7/1444838707.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751973,
+        85633745,
+        85687655
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
-    "wof:geomhash":"8433bb4f7cff3e7e0008c153d068c9a3",
-    "wof:hierarchy":[],
+    "wof:geomhash":"1c9f7b1fce0f2741fe3f0ff7d018dffc",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101751973,
+            "neighbourhood_id":1444838707,
+            "region_id":85687655
+        }
+    ],
     "wof:id":1444838707,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339157,
     "wof:name":"Cetate",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751973,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    21.228381453787147,
+    21.22838145378715,
     45.75574276645687,
-    21.228381453787147,
+    21.22838145378715,
     45.75574276645687
 ],
   "geometry": {"coordinates":[21.22838145378715,45.75574276645687],"type":"Point"}

--- a/data/144/483/870/7/1444838707.geojson
+++ b/data/144/483/870/7/1444838707.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838707,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"21.2283814538,45.7557427665,21.2283814538,45.7557427665",
+    "geom:latitude":45.755743,
+    "geom:longitude":21.228381,
+    "iso:country":"RO",
+    "lbl:latitude":45.755743,
+    "lbl:longitude":21.228381,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Cetate"
+    ],
+    "name:ron_x_preferred":[
+        "Cetate"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"8433bb4f7cff3e7e0008c153d068c9a3",
+    "wof:hierarchy":[],
+    "wof:id":1444838707,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Cetate",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    21.228381453787147,
+    45.75574276645687,
+    21.228381453787147,
+    45.75574276645687
+],
+  "geometry": {"coordinates":[21.22838145378715,45.75574276645687],"type":"Point"}
+}

--- a/data/144/483/872/1/1444838721.geojson
+++ b/data/144/483/872/1/1444838721.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444838721,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"21.208812047,45.7426262501,21.208812047,45.7426262501",
+    "geom:latitude":45.742626,
+    "geom:longitude":21.208812,
+    "iso:country":"RO",
+    "lbl:latitude":45.742626,
+    "lbl:longitude":21.208812,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Iosefin"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"7ba08a9336de9008a61b20f4d798dbe3",
+    "wof:hierarchy":[],
+    "wof:id":1444838721,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Iosefin",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    21.208812046968106,
+    45.74262625014939,
+    21.208812046968106,
+    45.74262625014939
+],
+  "geometry": {"coordinates":[21.20881204696811,45.74262625014939],"type":"Point"}
+}

--- a/data/144/483/872/1/1444838721.geojson
+++ b/data/144/483/872/1/1444838721.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751973,
+        85633745,
+        85687655
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
-    "wof:geomhash":"7ba08a9336de9008a61b20f4d798dbe3",
-    "wof:hierarchy":[],
+    "wof:geomhash":"1eb06d09d189003b692853fbfc1bc496",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101751973,
+            "neighbourhood_id":1444838721,
+            "region_id":85687655
+        }
+    ],
     "wof:id":1444838721,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339157,
     "wof:name":"Iosefin",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751973,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],
@@ -42,9 +55,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    21.208812046968106,
+    21.20881204696811,
     45.74262625014939,
-    21.208812046968106,
+    21.20881204696811,
     45.74262625014939
 ],
   "geometry": {"coordinates":[21.20881204696811,45.74262625014939],"type":"Point"}

--- a/data/144/483/872/7/1444838727.geojson
+++ b/data/144/483/872/7/1444838727.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838727,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"21.1825478431,45.7292070938,21.1825478431,45.7292070938",
+    "geom:latitude":45.729207,
+    "geom:longitude":21.182548,
+    "iso:country":"RO",
+    "lbl:latitude":45.729207,
+    "lbl:longitude":21.182548,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Freidorf"
+    ],
+    "name:ron_x_preferred":[
+        "Freidorf"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"bd833e7c0af837a5d0d7a5ec79fe89b8",
+    "wof:hierarchy":[],
+    "wof:id":1444838727,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Freidorf",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    21.18254784307938,
+    45.72920709381472,
+    21.18254784307938,
+    45.72920709381472
+],
+  "geometry": {"coordinates":[21.18254784307938,45.72920709381472],"type":"Point"}
+}

--- a/data/144/483/872/7/1444838727.geojson
+++ b/data/144/483/872/7/1444838727.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751973,
+        85633745,
+        85687655
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
     "wof:geomhash":"bd833e7c0af837a5d0d7a5ec79fe89b8",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101751973,
+            "neighbourhood_id":1444838727,
+            "region_id":85687655
+        }
+    ],
     "wof:id":1444838727,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339158,
     "wof:name":"Freidorf",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751973,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],

--- a/data/144/483/873/7/1444838737.geojson
+++ b/data/144/483/873/7/1444838737.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838737,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"21.201430604,45.7324423655,21.201430604,45.7324423655",
+    "geom:latitude":45.732442,
+    "geom:longitude":21.201431,
+    "iso:country":"RO",
+    "lbl:latitude":45.732442,
+    "lbl:longitude":21.201431,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Dambovita"
+    ],
+    "name:ron_x_preferred":[
+        "D\u00e2mbovi\u021ba"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"f501e2b063e906c3037572e4f3c214cd",
+    "wof:hierarchy":[],
+    "wof:id":1444838737,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Dambovita",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    21.201430604045125,
+    45.73244236547683,
+    21.201430604045125,
+    45.73244236547683
+],
+  "geometry": {"coordinates":[21.20143060404513,45.73244236547683],"type":"Point"}
+}

--- a/data/144/483/873/7/1444838737.geojson
+++ b/data/144/483/873/7/1444838737.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751973,
+        85633745,
+        85687655
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
-    "wof:geomhash":"f501e2b063e906c3037572e4f3c214cd",
-    "wof:hierarchy":[],
+    "wof:geomhash":"a46fd40f3878f148df5588fef5b3e8e2",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101751973,
+            "neighbourhood_id":1444838737,
+            "region_id":85687655
+        }
+    ],
     "wof:id":1444838737,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339161,
     "wof:name":"Dambovita",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751973,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    21.201430604045125,
+    21.20143060404513,
     45.73244236547683,
-    21.201430604045125,
+    21.20143060404513,
     45.73244236547683
 ],
   "geometry": {"coordinates":[21.20143060404513,45.73244236547683],"type":"Point"}

--- a/data/144/483/874/7/1444838747.geojson
+++ b/data/144/483/874/7/1444838747.geojson
@@ -1,0 +1,57 @@
+{
+  "id": 1444838747,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"21.2033188801,45.7555032231,21.2033188801,45.7555032231",
+    "geom:latitude":45.755503,
+    "geom:longitude":21.203319,
+    "iso:country":"RO",
+    "lbl:latitude":45.755503,
+    "lbl:longitude":21.203319,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Blascovici"
+    ],
+    "name:ron_x_preferred":[
+        "Bla\u0219covici"
+    ],
+    "name:ron_x_variant":[
+        "Blajcovici"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"d6077ec5c1d82dc2b9f9c53ef4312708",
+    "wof:hierarchy":[],
+    "wof:id":1444838747,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Blascovici",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    21.2033188801417,
+    45.75550322312999,
+    21.2033188801417,
+    45.75550322312999
+],
+  "geometry": {"coordinates":[21.2033188801417,45.75550322312999],"type":"Point"}
+}

--- a/data/144/483/874/7/1444838747.geojson
+++ b/data/144/483/874/7/1444838747.geojson
@@ -32,15 +32,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751973,
+        85633745,
+        85687655
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
     "wof:geomhash":"d6077ec5c1d82dc2b9f9c53ef4312708",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101751973,
+            "neighbourhood_id":1444838747,
+            "region_id":85687655
+        }
+    ],
     "wof:id":1444838747,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339162,
     "wof:name":"Blascovici",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751973,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],

--- a/data/144/483/875/7/1444838757.geojson
+++ b/data/144/483/875/7/1444838757.geojson
@@ -1,0 +1,57 @@
+{
+  "id": 1444838757,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"21.2234032714,45.7758008698,21.2234032714,45.7758008698",
+    "geom:latitude":45.775801,
+    "geom:longitude":21.223403,
+    "iso:country":"RO",
+    "lbl:latitude":45.775801,
+    "lbl:longitude":21.223403,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Aradului"
+    ],
+    "name:ron_x_preferred":[
+        "Aradului"
+    ],
+    "name:ron_x_variant":[
+        "Calea Aradului"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"6dbadb80a4ce05e2d4c33c1f944d600c",
+    "wof:hierarchy":[],
+    "wof:id":1444838757,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Aradului",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    21.223403271350723,
+    45.77580086976048,
+    21.223403271350723,
+    45.77580086976048
+],
+  "geometry": {"coordinates":[21.22340327135072,45.77580086976048],"type":"Point"}
+}

--- a/data/144/483/875/7/1444838757.geojson
+++ b/data/144/483/875/7/1444838757.geojson
@@ -32,15 +32,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751973,
+        85633745,
+        85687655
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
-    "wof:geomhash":"6dbadb80a4ce05e2d4c33c1f944d600c",
-    "wof:hierarchy":[],
+    "wof:geomhash":"775a383fb5b3128ae944640e1f93e0f9",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101751973,
+            "neighbourhood_id":1444838757,
+            "region_id":85687655
+        }
+    ],
     "wof:id":1444838757,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339162,
     "wof:name":"Aradului",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751973,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],
@@ -48,9 +61,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    21.223403271350723,
+    21.22340327135072,
     45.77580086976048,
-    21.223403271350723,
+    21.22340327135072,
     45.77580086976048
 ],
   "geometry": {"coordinates":[21.22340327135072,45.77580086976048],"type":"Point"}

--- a/data/144/483/876/7/1444838767.geojson
+++ b/data/144/483/876/7/1444838767.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838767,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"21.2500107982,45.757239889,21.2500107982,45.757239889",
+    "geom:latitude":45.75724,
+    "geom:longitude":21.250011,
+    "iso:country":"RO",
+    "lbl:latitude":45.75724,
+    "lbl:longitude":21.250011,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Fabric"
+    ],
+    "name:ron_x_preferred":[
+        "Fabric"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"2e41664620fd7f4243e7eb28de5f24b0",
+    "wof:hierarchy":[],
+    "wof:id":1444838767,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Fabric",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    21.250010798166095,
+    45.75723988895351,
+    21.250010798166095,
+    45.75723988895351
+],
+  "geometry": {"coordinates":[21.25001079816609,45.75723988895351],"type":"Point"}
+}

--- a/data/144/483/876/7/1444838767.geojson
+++ b/data/144/483/876/7/1444838767.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751973,
+        85633745,
+        85687655
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
-    "wof:geomhash":"2e41664620fd7f4243e7eb28de5f24b0",
-    "wof:hierarchy":[],
+    "wof:geomhash":"275cb31b0b5078dfa12f2461a682b9a2",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101751973,
+            "neighbourhood_id":1444838767,
+            "region_id":85687655
+        }
+    ],
     "wof:id":1444838767,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339163,
     "wof:name":"Fabric",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751973,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    21.250010798166095,
+    21.25001079816609,
     45.75723988895351,
-    21.250010798166095,
+    21.25001079816609,
     45.75723988895351
 ],
   "geometry": {"coordinates":[21.25001079816609,45.75723988895351],"type":"Point"}

--- a/data/144/483/877/5/1444838775.geojson
+++ b/data/144/483/877/5/1444838775.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838775,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"21.2379944957,45.7616112568,21.2379944957,45.7616112568",
+    "geom:latitude":45.761611,
+    "geom:longitude":21.237994,
+    "iso:country":"RO",
+    "lbl:latitude":45.761611,
+    "lbl:longitude":21.237994,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Tipografilor"
+    ],
+    "name:ron_x_preferred":[
+        "Tipografilor"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"edba4768b3a4347f17b10efd078b6c57",
+    "wof:hierarchy":[],
+    "wof:id":1444838775,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Tipografilor",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    21.237994495733343,
+    45.761611256764375,
+    21.237994495733343,
+    45.761611256764375
+],
+  "geometry": {"coordinates":[21.23799449573334,45.76161125676438],"type":"Point"}
+}

--- a/data/144/483/877/5/1444838775.geojson
+++ b/data/144/483/877/5/1444838775.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751973,
+        85633745,
+        85687655
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
-    "wof:geomhash":"edba4768b3a4347f17b10efd078b6c57",
-    "wof:hierarchy":[],
+    "wof:geomhash":"5074c27420417209ab00cd57f15ab1d7",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101751973,
+            "neighbourhood_id":1444838775,
+            "region_id":85687655
+        }
+    ],
     "wof:id":1444838775,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339166,
     "wof:name":"Tipografilor",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751973,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],
@@ -45,10 +58,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    21.237994495733343,
-    45.761611256764375,
-    21.237994495733343,
-    45.761611256764375
+    21.23799449573334,
+    45.76161125676438,
+    21.23799449573334,
+    45.76161125676438
 ],
   "geometry": {"coordinates":[21.23799449573334,45.76161125676438],"type":"Point"}
 }

--- a/data/144/483/877/9/1444838779.geojson
+++ b/data/144/483/877/9/1444838779.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838779,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"21.2531865352,45.7669402693,21.2531865352,45.7669402693",
+    "geom:latitude":45.76694,
+    "geom:longitude":21.253187,
+    "iso:country":"RO",
+    "lbl:latitude":45.76694,
+    "lbl:longitude":21.253187,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Telegrafului"
+    ],
+    "name:ron_x_preferred":[
+        "Telegrafului"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"27c4a7573a3e0103a51e04e2028ef73e",
+    "wof:hierarchy":[],
+    "wof:id":1444838779,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Telegrafului",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    21.253186535237603,
+    45.766940269297,
+    21.253186535237603,
+    45.766940269297
+],
+  "geometry": {"coordinates":[21.2531865352376,45.766940269297],"type":"Point"}
+}

--- a/data/144/483/877/9/1444838779.geojson
+++ b/data/144/483/877/9/1444838779.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751973,
+        85633745,
+        85687655
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
-    "wof:geomhash":"27c4a7573a3e0103a51e04e2028ef73e",
-    "wof:hierarchy":[],
+    "wof:geomhash":"61b5e099aa4c4253c40c18e5bb6b675e",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101751973,
+            "neighbourhood_id":1444838779,
+            "region_id":85687655
+        }
+    ],
     "wof:id":1444838779,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339167,
     "wof:name":"Telegrafului",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751973,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    21.253186535237603,
+    21.2531865352376,
     45.766940269297,
-    21.253186535237603,
+    21.2531865352376,
     45.766940269297
 ],
   "geometry": {"coordinates":[21.2531865352376,45.766940269297],"type":"Point"}

--- a/data/144/483/878/9/1444838789.geojson
+++ b/data/144/483/878/9/1444838789.geojson
@@ -34,15 +34,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751973,
+        85633745,
+        85687655
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
-    "wof:geomhash":"2a65a0a925c0eee7751d0ae8c8a3c970",
-    "wof:hierarchy":[],
+    "wof:geomhash":"eae68832068a9a666d79912a5ed867fc",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101751973,
+            "neighbourhood_id":1444838789,
+            "region_id":85687655
+        }
+    ],
     "wof:id":1444838789,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339167,
     "wof:name":"Ghiroda Noua",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751973,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],
@@ -51,9 +64,9 @@
 },
   "bbox": [
     21.27558835620151,
-    45.761611256828644,
+    45.76161125682864,
     21.27558835620151,
-    45.761611256828644
+    45.76161125682864
 ],
   "geometry": {"coordinates":[21.27558835620151,45.76161125682864],"type":"Point"}
 }

--- a/data/144/483/878/9/1444838789.geojson
+++ b/data/144/483/878/9/1444838789.geojson
@@ -1,0 +1,59 @@
+{
+  "id": 1444838789,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"21.2755883562,45.7616112568,21.2755883562,45.7616112568",
+    "geom:latitude":45.761611,
+    "geom:longitude":21.275588,
+    "iso:country":"RO",
+    "lbl:latitude":45.761611,
+    "lbl:longitude":21.275588,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Ghiroda Noua"
+    ],
+    "name:ron_x_preferred":[
+        "Ghiroda Noua"
+    ],
+    "name:ron_x_variant":[
+        "Colonia Cri\u015fan",
+        "Ghiroda Nou\u0103",
+        "Cri\u015fan"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"2a65a0a925c0eee7751d0ae8c8a3c970",
+    "wof:hierarchy":[],
+    "wof:id":1444838789,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Ghiroda Noua",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    21.27558835620151,
+    45.761611256828644,
+    21.27558835620151,
+    45.761611256828644
+],
+  "geometry": {"coordinates":[21.27558835620151,45.76161125682864],"type":"Point"}
+}

--- a/data/144/483/879/5/1444838795.geojson
+++ b/data/144/483/879/5/1444838795.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751973,
+        85633745,
+        85687655
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
-    "wof:geomhash":"f81c86935cb6e19f254b767d26915919",
-    "wof:hierarchy":[],
+    "wof:geomhash":"26fdcc5662586211c37733e7b92aef5b",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101751973,
+            "neighbourhood_id":1444838795,
+            "region_id":85687655
+        }
+    ],
     "wof:id":1444838795,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339168,
     "wof:name":"Plopi",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751973,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    21.280051554247965,
+    21.28005155424797,
     45.75089181367323,
-    21.280051554247965,
+    21.28005155424797,
     45.75089181367323
 ],
   "geometry": {"coordinates":[21.28005155424797,45.75089181367323],"type":"Point"}

--- a/data/144/483/879/5/1444838795.geojson
+++ b/data/144/483/879/5/1444838795.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838795,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"21.2800515542,45.7508918137,21.2800515542,45.7508918137",
+    "geom:latitude":45.750892,
+    "geom:longitude":21.280052,
+    "iso:country":"RO",
+    "lbl:latitude":45.750892,
+    "lbl:longitude":21.280051,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Plopi"
+    ],
+    "name:ron_x_preferred":[
+        "Plopi"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"f81c86935cb6e19f254b767d26915919",
+    "wof:hierarchy":[],
+    "wof:id":1444838795,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Plopi",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    21.280051554247965,
+    45.75089181367323,
+    21.280051554247965,
+    45.75089181367323
+],
+  "geometry": {"coordinates":[21.28005155424797,45.75089181367323],"type":"Point"}
+}

--- a/data/144/483/880/1/1444838801.geojson
+++ b/data/144/483/880/1/1444838801.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838801,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"21.2661040604,45.7474779275,21.2661040604,45.7474779275",
+    "geom:latitude":45.747478,
+    "geom:longitude":21.266104,
+    "iso:country":"RO",
+    "lbl:latitude":45.747478,
+    "lbl:longitude":21.266104,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Kuncz"
+    ],
+    "name:ron_x_preferred":[
+        "Kunz"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"1e01f46329d3551f73eb745d16618f8e",
+    "wof:hierarchy":[],
+    "wof:id":1444838801,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Kuncz",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    21.266104060352813,
+    45.74747792747333,
+    21.266104060352813,
+    45.74747792747333
+],
+  "geometry": {"coordinates":[21.26610406035281,45.74747792747333],"type":"Point"}
+}

--- a/data/144/483/880/1/1444838801.geojson
+++ b/data/144/483/880/1/1444838801.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751973,
+        85633745,
+        85687655
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
-    "wof:geomhash":"1e01f46329d3551f73eb745d16618f8e",
-    "wof:hierarchy":[],
+    "wof:geomhash":"cf895abc1cee96fbfc6f9e665cd87f92",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101751973,
+            "neighbourhood_id":1444838801,
+            "region_id":85687655
+        }
+    ],
     "wof:id":1444838801,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339171,
     "wof:name":"Kuncz",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751973,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    21.266104060352813,
+    21.26610406035281,
     45.74747792747333,
-    21.266104060352813,
+    21.26610406035281,
     45.74747792747333
 ],
   "geometry": {"coordinates":[21.26610406035281,45.74747792747333],"type":"Point"}

--- a/data/144/483/880/9/1444838809.geojson
+++ b/data/144/483/880/9/1444838809.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444838809,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"21.2597955016,45.7544851525,21.2597955016,45.7544851525",
+    "geom:latitude":45.754485,
+    "geom:longitude":21.259796,
+    "iso:country":"RO",
+    "lbl:latitude":45.754485,
+    "lbl:longitude":21.259795,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Lunei"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"f0e117ff687b99bfb36f666ee3218627",
+    "wof:hierarchy":[],
+    "wof:id":1444838809,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Lunei",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    21.259795501575617,
+    45.7544851525192,
+    21.259795501575617,
+    45.7544851525192
+],
+  "geometry": {"coordinates":[21.25979550157562,45.7544851525192],"type":"Point"}
+}

--- a/data/144/483/880/9/1444838809.geojson
+++ b/data/144/483/880/9/1444838809.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751973,
+        85633745,
+        85687655
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
-    "wof:geomhash":"f0e117ff687b99bfb36f666ee3218627",
-    "wof:hierarchy":[],
+    "wof:geomhash":"5fcdca53894628261ffa54e32b4d4e5a",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101751973,
+            "neighbourhood_id":1444838809,
+            "region_id":85687655
+        }
+    ],
     "wof:id":1444838809,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339171,
     "wof:name":"Lunei",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751973,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],
@@ -42,9 +55,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    21.259795501575617,
+    21.25979550157562,
     45.7544851525192,
-    21.259795501575617,
+    21.25979550157562,
     45.7544851525192
 ],
   "geometry": {"coordinates":[21.25979550157562,45.7544851525192],"type":"Point"}

--- a/data/144/483/881/5/1444838815.geojson
+++ b/data/144/483/881/5/1444838815.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838815,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"21.2667907062,45.7640063816,21.2667907062,45.7640063816",
+    "geom:latitude":45.764006,
+    "geom:longitude":21.266791,
+    "iso:country":"RO",
+    "lbl:latitude":45.764006,
+    "lbl:longitude":21.266791,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Modern"
+    ],
+    "name:ron_x_preferred":[
+        "Modern"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"b14f19661b2b7504be4763ec18210297",
+    "wof:hierarchy":[],
+    "wof:id":1444838815,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Modern",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    21.266790706206105,
+    45.764006381557074,
+    21.266790706206105,
+    45.764006381557074
+],
+  "geometry": {"coordinates":[21.26679070620611,45.76400638155707],"type":"Point"}
+}

--- a/data/144/483/881/5/1444838815.geojson
+++ b/data/144/483/881/5/1444838815.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751973,
+        85633745,
+        85687655
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
-    "wof:geomhash":"b14f19661b2b7504be4763ec18210297",
-    "wof:hierarchy":[],
+    "wof:geomhash":"7152aa39d7a24238e932803037d2bcaf",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101751973,
+            "neighbourhood_id":1444838815,
+            "region_id":85687655
+        }
+    ],
     "wof:id":1444838815,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339172,
     "wof:name":"Modern",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751973,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],
@@ -45,10 +58,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    21.266790706206105,
-    45.764006381557074,
-    21.266790706206105,
-    45.764006381557074
+    21.26679070620611,
+    45.76400638155707,
+    21.26679070620611,
+    45.76400638155707
 ],
   "geometry": {"coordinates":[21.26679070620611,45.76400638155707],"type":"Point"}
 }

--- a/data/144/483/882/1/1444838821.geojson
+++ b/data/144/483/882/1/1444838821.geojson
@@ -32,15 +32,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751973,
+        85633745,
+        85687655
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
-    "wof:geomhash":"ace0a0de8ed1dd4de76c6f0fd7ffb994",
-    "wof:hierarchy":[],
+    "wof:geomhash":"dc3aaa51de85b8501a73538f2fb298ff",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101751973,
+            "neighbourhood_id":1444838821,
+            "region_id":85687655
+        }
+    ],
     "wof:id":1444838821,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339173,
     "wof:name":"Lipovei",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751973,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],
@@ -48,9 +61,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    21.241041486707363,
+    21.24104148670736,
     45.77418451478789,
-    21.241041486707363,
+    21.24104148670736,
     45.77418451478789
 ],
   "geometry": {"coordinates":[21.24104148670736,45.77418451478789],"type":"Point"}

--- a/data/144/483/882/1/1444838821.geojson
+++ b/data/144/483/882/1/1444838821.geojson
@@ -1,0 +1,57 @@
+{
+  "id": 1444838821,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"21.2410414867,45.7741845148,21.2410414867,45.7741845148",
+    "geom:latitude":45.774185,
+    "geom:longitude":21.241041,
+    "iso:country":"RO",
+    "lbl:latitude":45.774184,
+    "lbl:longitude":21.241041,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Lipovei"
+    ],
+    "name:ron_x_preferred":[
+        "Lipovei"
+    ],
+    "name:ron_x_variant":[
+        "Calea Lipovei"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"ace0a0de8ed1dd4de76c6f0fd7ffb994",
+    "wof:hierarchy":[],
+    "wof:id":1444838821,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Lipovei",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    21.241041486707363,
+    45.77418451478789,
+    21.241041486707363,
+    45.77418451478789
+],
+  "geometry": {"coordinates":[21.24104148670736,45.77418451478789],"type":"Point"}
+}

--- a/data/144/483/882/7/1444838827.geojson
+++ b/data/144/483/882/7/1444838827.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838827,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"21.2147772828,45.7719694325,21.2147772828,45.7719694325",
+    "geom:latitude":45.771969,
+    "geom:longitude":21.214777,
+    "iso:country":"RO",
+    "lbl:latitude":45.771969,
+    "lbl:longitude":21.214777,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Torontalalui"
+    ],
+    "name:ron_x_preferred":[
+        "Torontalalui"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"72353ac7a4b16b40848415f271a8eae7",
+    "wof:hierarchy":[],
+    "wof:id":1444838827,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Torontalalui",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    21.214777282818638,
+    45.77196943253609,
+    21.214777282818638,
+    45.77196943253609
+],
+  "geometry": {"coordinates":[21.21477728281864,45.77196943253609],"type":"Point"}
+}

--- a/data/144/483/882/7/1444838827.geojson
+++ b/data/144/483/882/7/1444838827.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751973,
+        85633745,
+        85687655
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
-    "wof:geomhash":"72353ac7a4b16b40848415f271a8eae7",
-    "wof:hierarchy":[],
+    "wof:geomhash":"1835a8fc290633c4af21c1702acedb3a",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101751973,
+            "neighbourhood_id":1444838827,
+            "region_id":85687655
+        }
+    ],
     "wof:id":1444838827,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339176,
     "wof:name":"Torontalalui",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751973,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    21.214777282818638,
+    21.21477728281864,
     45.77196943253609,
-    21.214777282818638,
+    21.21477728281864,
     45.77196943253609
 ],
   "geometry": {"coordinates":[21.21477728281864,45.77196943253609],"type":"Point"}

--- a/data/144/483/883/1/1444838831.geojson
+++ b/data/144/483/883/1/1444838831.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838831,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"21.2039626106,45.7652637809,21.2039626106,45.7652637809",
+    "geom:latitude":45.765264,
+    "geom:longitude":21.203963,
+    "iso:country":"RO",
+    "lbl:latitude":45.765264,
+    "lbl:longitude":21.203963,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Mehala"
+    ],
+    "name:ron_x_preferred":[
+        "Mehala"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"6c9116f58e5d8e2cba53eafc2384c327",
+    "wof:hierarchy":[],
+    "wof:id":1444838831,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Mehala",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    21.203962610629173,
+    45.765263780911106,
+    21.203962610629173,
+    45.765263780911106
+],
+  "geometry": {"coordinates":[21.20396261062917,45.76526378091111],"type":"Point"}
+}

--- a/data/144/483/883/1/1444838831.geojson
+++ b/data/144/483/883/1/1444838831.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751973,
+        85633745,
+        85687655
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
-    "wof:geomhash":"6c9116f58e5d8e2cba53eafc2384c327",
-    "wof:hierarchy":[],
+    "wof:geomhash":"baee690e0241439cfeb9012d3f6658e8",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101751973,
+            "neighbourhood_id":1444838831,
+            "region_id":85687655
+        }
+    ],
     "wof:id":1444838831,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339177,
     "wof:name":"Mehala",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751973,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],
@@ -45,10 +58,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    21.203962610629173,
-    45.765263780911106,
-    21.203962610629173,
-    45.765263780911106
+    21.20396261062917,
+    45.76526378091111,
+    21.20396261062917,
+    45.76526378091111
 ],
   "geometry": {"coordinates":[21.20396261062917,45.76526378091111],"type":"Point"}
 }

--- a/data/144/483/883/5/1444838835.geojson
+++ b/data/144/483/883/5/1444838835.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751973,
+        85633745,
+        85687655
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
-    "wof:geomhash":"8f76e0d372fe3d8ac27c6ee31963479d",
-    "wof:hierarchy":[],
+    "wof:geomhash":"8859a92a166451c62fcb5faa282fb4eb",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101751973,
+            "neighbourhood_id":1444838835,
+            "region_id":85687655
+        }
+    ],
     "wof:id":1444838835,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339177,
     "wof:name":"Braytim",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751973,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],
@@ -42,10 +55,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    21.243101424267262,
-    45.726091469907416,
-    21.243101424267262,
-    45.726091469907416
+    21.24310142426726,
+    45.72609146990742,
+    21.24310142426726,
+    45.72609146990742
 ],
   "geometry": {"coordinates":[21.24310142426726,45.72609146990742],"type":"Point"}
 }

--- a/data/144/483/883/5/1444838835.geojson
+++ b/data/144/483/883/5/1444838835.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444838835,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"21.2431014243,45.7260914699,21.2431014243,45.7260914699",
+    "geom:latitude":45.726091,
+    "geom:longitude":21.243101,
+    "iso:country":"RO",
+    "lbl:latitude":45.726091,
+    "lbl:longitude":21.243101,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Braytim"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"8f76e0d372fe3d8ac27c6ee31963479d",
+    "wof:hierarchy":[],
+    "wof:id":1444838835,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Braytim",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    21.243101424267262,
+    45.726091469907416,
+    21.243101424267262,
+    45.726091469907416
+],
+  "geometry": {"coordinates":[21.24310142426726,45.72609146990742],"type":"Point"}
+}

--- a/data/144/483/883/9/1444838839.geojson
+++ b/data/144/483/883/9/1444838839.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838839,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"21.2319434292,45.7334608381,21.2319434292,45.7334608381",
+    "geom:latitude":45.733461,
+    "geom:longitude":21.231943,
+    "iso:country":"RO",
+    "lbl:latitude":45.733461,
+    "lbl:longitude":21.231943,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Girocului"
+    ],
+    "name:ron_x_preferred":[
+        "Girocului"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"e76b5769816f3d7d40480c07ae03940b",
+    "wof:hierarchy":[],
+    "wof:id":1444838839,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Girocului",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    21.231943429151148,
+    45.73346083814059,
+    21.231943429151148,
+    45.73346083814059
+],
+  "geometry": {"coordinates":[21.23194342915115,45.73346083814059],"type":"Point"}
+}

--- a/data/144/483/883/9/1444838839.geojson
+++ b/data/144/483/883/9/1444838839.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751973,
+        85633745,
+        85687655
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
-    "wof:geomhash":"e76b5769816f3d7d40480c07ae03940b",
-    "wof:hierarchy":[],
+    "wof:geomhash":"11b1976e2e9e3e31877b3e74acef88a1",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101751973,
+            "neighbourhood_id":1444838839,
+            "region_id":85687655
+        }
+    ],
     "wof:id":1444838839,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339178,
     "wof:name":"Girocului",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751973,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    21.231943429151148,
+    21.23194342915115,
     45.73346083814059,
-    21.231943429151148,
+    21.23194342915115,
     45.73346083814059
 ],
   "geometry": {"coordinates":[21.23194342915115,45.73346083814059],"type":"Point"}

--- a/data/144/483/884/5/1444838845.geojson
+++ b/data/144/483/884/5/1444838845.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838845,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"21.2455905155,45.7342396576,21.2455905155,45.7342396576",
+    "geom:latitude":45.73424,
+    "geom:longitude":21.245591,
+    "iso:country":"RO",
+    "lbl:latitude":45.73424,
+    "lbl:longitude":21.24559,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Soarelui"
+    ],
+    "name:ron_x_preferred":[
+        "Soarelui"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"d72fd67be3563fa620ec797bcf8032d4",
+    "wof:hierarchy":[],
+    "wof:id":1444838845,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Soarelui",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    21.245590515485482,
+    45.73423965764543,
+    21.245590515485482,
+    45.73423965764543
+],
+  "geometry": {"coordinates":[21.24559051548548,45.73423965764543],"type":"Point"}
+}

--- a/data/144/483/884/5/1444838845.geojson
+++ b/data/144/483/884/5/1444838845.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751973,
+        85633745,
+        85687655
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
-    "wof:geomhash":"d72fd67be3563fa620ec797bcf8032d4",
-    "wof:hierarchy":[],
+    "wof:geomhash":"dcd62f65df746f8fba659a9fe6820062",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101751973,
+            "neighbourhood_id":1444838845,
+            "region_id":85687655
+        }
+    ],
     "wof:id":1444838845,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339181,
     "wof:name":"Soarelui",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751973,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    21.245590515485482,
+    21.24559051548548,
     45.73423965764543,
-    21.245590515485482,
+    21.24559051548548,
     45.73423965764543
 ],
   "geometry": {"coordinates":[21.24559051548548,45.73423965764543],"type":"Point"}

--- a/data/144/483/884/9/1444838849.geojson
+++ b/data/144/483/884/9/1444838849.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838849,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"21.2019885038,45.7706523143,21.2019885038,45.7706523143",
+    "geom:latitude":45.770652,
+    "geom:longitude":21.201989,
+    "iso:country":"RO",
+    "lbl:latitude":45.770652,
+    "lbl:longitude":21.201988,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Bucovina"
+    ],
+    "name:ron_x_preferred":[
+        "Bucovina"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"cee25405c7ce15fec14b80be496e8441",
+    "wof:hierarchy":[],
+    "wof:id":1444838849,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Bucovina",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    21.201988503800944,
+    45.77065231427968,
+    21.201988503800944,
+    45.77065231427968
+],
+  "geometry": {"coordinates":[21.20198850380094,45.77065231427968],"type":"Point"}
+}

--- a/data/144/483/884/9/1444838849.geojson
+++ b/data/144/483/884/9/1444838849.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751973,
+        85633745,
+        85687655
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
-    "wof:geomhash":"cee25405c7ce15fec14b80be496e8441",
-    "wof:hierarchy":[],
+    "wof:geomhash":"4e659c8a7358788f2b60619502b2cbec",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101751973,
+            "neighbourhood_id":1444838849,
+            "region_id":85687655
+        }
+    ],
     "wof:id":1444838849,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339182,
     "wof:name":"Bucovina",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751973,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    21.201988503800944,
+    21.20198850380094,
     45.77065231427968,
-    21.201988503800944,
+    21.20198850380094,
     45.77065231427968
 ],
   "geometry": {"coordinates":[21.20198850380094,45.77065231427968],"type":"Point"}

--- a/data/144/483/885/1/1444838851.geojson
+++ b/data/144/483/885/1/1444838851.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838851,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"21.2037051184,45.7233351962,21.2037051184,45.7233351962",
+    "geom:latitude":45.723335,
+    "geom:longitude":21.203705,
+    "iso:country":"RO",
+    "lbl:latitude":45.723335,
+    "lbl:longitude":21.203705,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Steaua"
+    ],
+    "name:ron_x_preferred":[
+        "Steaua"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"RO",
+    "wof:geomhash":"f7843583d2188051fe2fc071631a3523",
+    "wof:hierarchy":[],
+    "wof:id":1444838851,
+    "wof:lastmodified":1566335356,
+    "wof:name":"Steaua",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-ro",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    21.203705118434193,
+    45.7233351962067,
+    21.203705118434193,
+    45.7233351962067
+],
+  "geometry": {"coordinates":[21.20370511843419,45.7233351962067],"type":"Point"}
+}

--- a/data/144/483/885/1/1444838851.geojson
+++ b/data/144/483/885/1/1444838851.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751973,
+        85633745,
+        85687655
+    ],
     "wof:breaches":[],
     "wof:country":"RO",
-    "wof:geomhash":"f7843583d2188051fe2fc071631a3523",
-    "wof:hierarchy":[],
+    "wof:geomhash":"3b2ca36721050dc6b02fd89d89855475",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633745,
+            "locality_id":101751973,
+            "neighbourhood_id":1444838851,
+            "region_id":85687655
+        }
+    ],
     "wof:id":1444838851,
-    "wof:lastmodified":1566335356,
+    "wof:lastmodified":1566339182,
     "wof:name":"Steaua",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751973,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ro",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    21.203705118434193,
+    21.20370511843419,
     45.7233351962067,
-    21.203705118434193,
+    21.20370511843419,
     45.7233351962067
 ],
   "geometry": {"coordinates":[21.20370511843419,45.7233351962067],"type":"Point"}


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1695.

This PR contains new neighbourhood records from Nat's neighbourhood import file. 