### PR TITLE
Update region ron and eng labels and names

### DIFF
--- a/data/856/875/81/85687581.geojson
+++ b/data/856/875/81/85687581.geojson
@@ -19,6 +19,12 @@
     "label:eng_x_preferred_shortcode":[
         "DJ"
     ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Dolj"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
+    ],
     "lbl:latitude":44.197101,
     "lbl:longitude":23.600363,
     "lbl:min_zoom":8.0,
@@ -32,6 +38,9 @@
         "Dolj"
     ],
     "name:ron_x_preferred":[
+        "Dolj"
+    ],
+    "name:ron_x_variant":[
         "Jude\u021bul Dolj"
     ],
     "name:und_x_variant":[
@@ -153,7 +162,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882932,
+    "wof:lastmodified":1585864407,
     "wof:name":"Dolj",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/875/85/85687585.geojson
+++ b/data/856/875/85/85687585.geojson
@@ -19,6 +19,12 @@
     "label:eng_x_preferred_shortcode":[
         "TR"
     ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Teleorman"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
+    ],
     "lbl:latitude":44.051642,
     "lbl:longitude":25.241148,
     "lbl:min_zoom":8.0,
@@ -41,10 +47,10 @@
         "Teleorman"
     ],
     "name:ron_x_preferred":[
-        "Jude\u0163ul Teleorman"
+        "Teleorman"
     ],
     "name:ron_x_variant":[
-        "Teleorman"
+        "Jude\u0163ul Teleorman"
     ],
     "name:slk_x_preferred":[
         "Teleorman"
@@ -165,7 +171,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882933,
+    "wof:lastmodified":1585864407,
     "wof:name":"Teleorman",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/875/91/85687591.geojson
+++ b/data/856/875/91/85687591.geojson
@@ -19,6 +19,12 @@
     "label:eng_x_preferred_shortcode":[
         "GR"
     ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Giurgiu"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
+    ],
     "lbl:latitude":44.075461,
     "lbl:longitude":25.913626,
     "lbl:min_zoom":8.0,
@@ -311,7 +317,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882932,
+    "wof:lastmodified":1585864407,
     "wof:name":"Giurgiu",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/875/95/85687595.geojson
+++ b/data/856/875/95/85687595.geojson
@@ -11,13 +11,22 @@
     "geom:longitude":26.087654,
     "iso:country":"RO",
     "label:eng_x_preferred_longname":[
-        "Bucure\u015fti City"
+        "Bucharest"
     ],
     "label:eng_x_preferred_placetype":[
         "city"
     ],
     "label:eng_x_preferred_shortcode":[
         "BI"
+    ],
+    "label:eng_x_variant_longname":[
+        "Bucure\u015fti City"
+    ],
+    "label:ron_x_preferred_longname":[
+        "Bucure\u015fti"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
     ],
     "lbl:latitude":44.435842,
     "lbl:longitude":26.085733,
@@ -156,7 +165,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882930,
+    "wof:lastmodified":1585864407,
     "wof:name":"Bucure\u015fti",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/875/99/85687599.geojson
+++ b/data/856/875/99/85687599.geojson
@@ -11,13 +11,22 @@
     "geom:longitude":22.783829,
     "iso:country":"RO",
     "label:eng_x_preferred_longname":[
-        "Mehedin\u0163i County"
+        "Mehedinti County"
     ],
     "label:eng_x_preferred_placetype":[
         "county"
     ],
     "label:eng_x_preferred_shortcode":[
         "MH"
+    ],
+    "label:eng_x_variant_longname":[
+        "Mehedin\u0163i County"
+    ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Mehedin\u0163i"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
     ],
     "lbl:latitude":44.51627,
     "lbl:longitude":22.974755,
@@ -180,7 +189,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882932,
+    "wof:lastmodified":1585864407,
     "wof:name":"Mehedin\u0163i",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/07/85687607.geojson
+++ b/data/856/876/07/85687607.geojson
@@ -19,6 +19,12 @@
     "label:eng_x_preferred_shortcode":[
         "OT"
     ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Olt"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
+    ],
     "lbl:latitude":44.291298,
     "lbl:longitude":24.487176,
     "lbl:min_zoom":8.0,
@@ -298,7 +304,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882933,
+    "wof:lastmodified":1585864409,
     "wof:name":"Olt",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/11/85687611.geojson
+++ b/data/856/876/11/85687611.geojson
@@ -19,6 +19,12 @@
     "label:eng_x_preferred_shortcode":[
         "IF"
     ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Ilfov"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
+    ],
     "lbl:latitude":44.607618,
     "lbl:longitude":26.213713,
     "lbl:min_zoom":8.0,
@@ -101,6 +107,9 @@
         "Okr\u0119g Ilfov"
     ],
     "name:ron_x_preferred":[
+        "Ilfov"
+    ],
+    "name:ron_x_variant":[
         "Jude\u021bul Ilfov"
     ],
     "name:rus_x_preferred":[
@@ -249,7 +258,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882932,
+    "wof:lastmodified":1585864409,
     "wof:name":"Ilfov",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/15/85687615.geojson
+++ b/data/856/876/15/85687615.geojson
@@ -11,13 +11,22 @@
     "geom:longitude":27.019001,
     "iso:country":"RO",
     "label:eng_x_preferred_longname":[
-        "C\u0103l\u0103ra\u015fi County"
+        "Calarasi County"
     ],
     "label:eng_x_preferred_placetype":[
         "county"
     ],
     "label:eng_x_preferred_shortcode":[
         "CL"
+    ],
+    "label:eng_x_variant_longname":[
+        "C\u0103l\u0103ra\u015fi County"
+    ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul C\u0103l\u0103ra\u015fi"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
     ],
     "lbl:latitude":44.328376,
     "lbl:longitude":26.93181,
@@ -146,6 +155,9 @@
         "C\u0103l\u0103ra\u0219i"
     ],
     "name:ron_x_preferred":[
+        "C\u0103l\u0103ra\u015fi"
+    ],
+    "name:ron_x_variant":[
         "C\u0103l\u0103ra\u0219i"
     ],
     "name:rus_x_preferred":[
@@ -317,7 +329,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882931,
+    "wof:lastmodified":1585864410,
     "wof:name":"C\u0103l\u0103ra\u015fi",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/19/85687619.geojson
+++ b/data/856/876/19/85687619.geojson
@@ -19,6 +19,12 @@
     "label:eng_x_preferred_shortcode":[
         "GJ"
     ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Gorj"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
+    ],
     "lbl:latitude":44.98217,
     "lbl:longitude":23.383098,
     "lbl:min_zoom":8.0,
@@ -32,6 +38,9 @@
         "Gorj"
     ],
     "name:ron_x_preferred":[
+        "Gorj"
+    ],
+    "name:ron_x_variant":[
         "Jude\u021bul Gorj"
     ],
     "name:und_x_variant":[
@@ -153,7 +162,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882932,
+    "wof:lastmodified":1585864409,
     "wof:name":"Gorj",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/21/85687621.geojson
+++ b/data/856/876/21/85687621.geojson
@@ -11,13 +11,22 @@
     "geom:longitude":27.254534,
     "iso:country":"RO",
     "label:eng_x_preferred_longname":[
-        "Ialomi\u0163a County"
+        "Ialomita County"
     ],
     "label:eng_x_preferred_placetype":[
         "county"
     ],
     "label:eng_x_preferred_shortcode":[
         "IL"
+    ],
+    "label:eng_x_variant_longname":[
+        "Ialomi\u0163a County"
+    ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Ialomi\u0163a"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
     ],
     "lbl:latitude":44.643615,
     "lbl:longitude":27.344059,
@@ -50,6 +59,9 @@
         "Ialomi\u0163a"
     ],
     "name:ron_x_preferred":[
+        "Ialomi\u0163a"
+    ],
+    "name:ron_x_variant":[
         "Ialomi\u021ba"
     ],
     "name:rus_x_preferred":[
@@ -181,7 +193,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882932,
+    "wof:lastmodified":1585864409,
     "wof:name":"Ialomi\u0163a",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/27/85687627.geojson
+++ b/data/856/876/27/85687627.geojson
@@ -11,13 +11,22 @@
     "geom:longitude":22.04099,
     "iso:country":"RO",
     "label:eng_x_preferred_longname":[
-        "Cara\u015f-Severin County"
+        "Caras-Severin County"
     ],
     "label:eng_x_preferred_placetype":[
         "county"
     ],
     "label:eng_x_preferred_shortcode":[
         "CS"
+    ],
+    "label:eng_x_variant_longname":[
+        "Cara\u015f-Severin County"
+    ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Cara\u015f-Severin"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
     ],
     "lbl:latitude":45.13537,
     "lbl:longitude":22.04136,
@@ -180,7 +189,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882931,
+    "wof:lastmodified":1585864409,
     "wof:name":"Cara\u015f-Severin",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/33/85687633.geojson
+++ b/data/856/876/33/85687633.geojson
@@ -11,13 +11,22 @@
     "geom:longitude":28.246469,
     "iso:country":"RO",
     "label:eng_x_preferred_longname":[
-        "Constan\u0163a County"
+        "Constanta County"
     ],
     "label:eng_x_preferred_placetype":[
         "county"
     ],
     "label:eng_x_preferred_shortcode":[
         "CT"
+    ],
+    "label:eng_x_variant_longname":[
+        "Constan\u0163a County"
+    ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Constan\u0163a"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
     ],
     "lbl:latitude":44.154529,
     "lbl:longitude":28.305084,
@@ -230,10 +239,11 @@
         "Constan\u00e7a"
     ],
     "name:ron_x_preferred":[
-        "Constan\u021ba"
+        "Constan\u0163a"
     ],
     "name:ron_x_variant":[
-        "Jude\u021bul Constan\u021ba"
+        "Jude\u021bul Constan\u021ba",
+        "Constan\u021ba"
     ],
     "name:rup_x_preferred":[
         "Constantsa"
@@ -444,7 +454,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882931,
+    "wof:lastmodified":1585864409,
     "wof:name":"Constan\u0163a",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/37/85687637.geojson
+++ b/data/856/876/37/85687637.geojson
@@ -11,13 +11,22 @@
     "geom:longitude":25.495709,
     "iso:country":"RO",
     "label:eng_x_preferred_longname":[
-        "D\u00e2mbovi\u0163a County"
+        "D\u00e2mbovita County"
     ],
     "label:eng_x_preferred_placetype":[
         "county"
     ],
     "label:eng_x_preferred_shortcode":[
         "DB"
+    ],
+    "label:eng_x_variant_longname":[
+        "D\u00e2mbovi\u0163a County"
+    ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul D\u00e2mbovi\u0163a"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
     ],
     "lbl:latitude":44.823657,
     "lbl:longitude":25.466503,
@@ -53,6 +62,9 @@
         "D\u00e2mbovi\u0163a"
     ],
     "name:ron_x_preferred":[
+        "D\u00e2mbovi\u0163a"
+    ],
+    "name:ron_x_variant":[
         "D\u00e2mbovi\u021ba"
     ],
     "name:slk_x_preferred":[
@@ -179,7 +191,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882931,
+    "wof:lastmodified":1585864409,
     "wof:name":"D\u00e2mbovi\u0163a",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/43/85687643.geojson
+++ b/data/856/876/43/85687643.geojson
@@ -19,6 +19,15 @@
     "label:eng_x_preferred_shortcode":[
         "VL"
     ],
+    "label:eng_x_variant_longname":[
+        "V\u00e2lcea County"
+    ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul V\u00e2lcea"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
+    ],
     "lbl:latitude":45.144043,
     "lbl:longitude":24.16603,
     "lbl:min_zoom":8.0,
@@ -180,7 +189,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882933,
+    "wof:lastmodified":1585864409,
     "wof:name":"V\u00e2lcea",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/45/85687645.geojson
+++ b/data/856/876/45/85687645.geojson
@@ -11,13 +11,22 @@
     "geom:longitude":24.886267,
     "iso:country":"RO",
     "label:eng_x_preferred_longname":[
-        "Arge\u015f County"
+        "Arges County"
     ],
     "label:eng_x_preferred_placetype":[
         "county"
     ],
     "label:eng_x_preferred_shortcode":[
         "AG"
+    ],
+    "label:eng_x_variant_longname":[
+        "Arge\u015f County"
+    ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Arge\u015f"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
     ],
     "lbl:latitude":45.02263,
     "lbl:longitude":24.832721,
@@ -50,6 +59,9 @@
         "Arge\u0219"
     ],
     "name:ron_x_preferred":[
+        "Arge\u015f"
+    ],
+    "name:ron_x_variant":[
         "Arge\u0219"
     ],
     "name:rus_x_preferred":[
@@ -181,7 +193,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882930,
+    "wof:lastmodified":1585864409,
     "wof:name":"Arge\u015f",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/55/85687655.geojson
+++ b/data/856/876/55/85687655.geojson
@@ -11,13 +11,22 @@
     "geom:longitude":21.376385,
     "iso:country":"RO",
     "label:eng_x_preferred_longname":[
-        "Timi\u015f County"
+        "Timis County"
     ],
     "label:eng_x_preferred_placetype":[
         "county"
     ],
     "label:eng_x_preferred_shortcode":[
         "TM"
+    ],
+    "label:eng_x_variant_longname":[
+        "Timi\u015f County"
+    ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Timi\u015f"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
     ],
     "lbl:latitude":45.658785,
     "lbl:longitude":21.168268,
@@ -63,6 +72,9 @@
         "Timi\u015f"
     ],
     "name:ron_x_preferred":[
+        "Timi\u015f"
+    ],
+    "name:ron_x_variant":[
         "Timi\u0219"
     ],
     "name:rus_x_preferred":[
@@ -188,7 +200,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882933,
+    "wof:lastmodified":1585864410,
     "wof:name":"Timi\u015f",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/61/85687661.geojson
+++ b/data/856/876/61/85687661.geojson
@@ -19,6 +19,12 @@
     "label:eng_x_preferred_shortcode":[
         "PH"
     ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Prahova"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
+    ],
     "lbl:latitude":45.096132,
     "lbl:longitude":26.005761,
     "lbl:min_zoom":8.0,
@@ -280,7 +286,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882933,
+    "wof:lastmodified":1585864409,
     "wof:name":"Prahova",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/63/85687663.geojson
+++ b/data/856/876/63/85687663.geojson
@@ -11,13 +11,22 @@
     "geom:longitude":27.671684,
     "iso:country":"RO",
     "label:eng_x_preferred_longname":[
-        "Br\u0103ila County"
+        "Braila County"
     ],
     "label:eng_x_preferred_placetype":[
         "county"
     ],
     "label:eng_x_preferred_shortcode":[
         "BR"
+    ],
+    "label:eng_x_variant_longname":[
+        "Br\u0103ila County"
+    ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Br\u0103ila"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
     ],
     "lbl:latitude":45.105486,
     "lbl:longitude":27.682118,
@@ -371,7 +380,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882931,
+    "wof:lastmodified":1585864410,
     "wof:name":"Br\u0103ila",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/67/85687667.geojson
+++ b/data/856/876/67/85687667.geojson
@@ -11,13 +11,22 @@
     "geom:longitude":26.748803,
     "iso:country":"RO",
     "label:eng_x_preferred_longname":[
-        "Buz\u0103u County"
+        "Buzau County"
     ],
     "label:eng_x_preferred_placetype":[
         "county"
     ],
     "label:eng_x_preferred_shortcode":[
         "BZ"
+    ],
+    "label:eng_x_variant_longname":[
+        "Buz\u0103u County"
+    ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Buz\u0103u"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
     ],
     "lbl:latitude":45.212938,
     "lbl:longitude":26.758679,
@@ -338,7 +347,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882931,
+    "wof:lastmodified":1585864409,
     "wof:name":"Buz\u0103u",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/71/85687671.geojson
+++ b/data/856/876/71/85687671.geojson
@@ -19,6 +19,12 @@
     "label:eng_x_preferred_shortcode":[
         "HD"
     ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Hunedoara"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
+    ],
     "lbl:latitude":45.736973,
     "lbl:longitude":22.937539,
     "lbl:min_zoom":8.0,
@@ -299,7 +305,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882932,
+    "wof:lastmodified":1585864410,
     "wof:name":"Hunedoara",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/79/85687679.geojson
+++ b/data/856/876/79/85687679.geojson
@@ -19,6 +19,12 @@
     "label:eng_x_preferred_shortcode":[
         "TL"
     ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Tulcea"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
+    ],
     "lbl:latitude":44.989885,
     "lbl:longitude":28.929893,
     "lbl:min_zoom":8.0,
@@ -369,7 +375,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882933,
+    "wof:lastmodified":1585864410,
     "wof:name":"Tulcea",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/83/85687683.geojson
+++ b/data/856/876/83/85687683.geojson
@@ -11,13 +11,22 @@
     "geom:longitude":25.300637,
     "iso:country":"RO",
     "label:eng_x_preferred_longname":[
-        "Bra\u015fov County"
+        "Brasov County"
     ],
     "label:eng_x_preferred_placetype":[
         "county"
     ],
     "label:eng_x_preferred_shortcode":[
         "BV"
+    ],
+    "label:eng_x_variant_longname":[
+        "Bra\u015fov County"
+    ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Bra\u015fov"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
     ],
     "lbl:latitude":45.836583,
     "lbl:longitude":25.250644,
@@ -228,6 +237,9 @@
         "\u0628\u0631\u0627\u0634\u0648\u0641"
     ],
     "name:ron_x_preferred":[
+        "Bra\u015fov"
+    ],
+    "name:ron_x_variant":[
         "Bra\u0219ov"
     ],
     "name:rup_x_preferred":[
@@ -432,7 +444,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882931,
+    "wof:lastmodified":1585864410,
     "wof:name":"Bra\u015fov",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/87/85687687.geojson
+++ b/data/856/876/87/85687687.geojson
@@ -19,6 +19,12 @@
     "label:eng_x_preferred_shortcode":[
         "SB"
     ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Sibiu"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
+    ],
     "lbl:latitude":45.880647,
     "lbl:longitude":24.311196,
     "lbl:min_zoom":8.0,
@@ -207,10 +213,10 @@
         "Sibiu"
     ],
     "name:ron_x_preferred":[
-        "Jude\u021bul Sibiu"
+        "Sibiu"
     ],
     "name:ron_x_variant":[
-        "Sibiu"
+        "Jude\u021bul Sibiu"
     ],
     "name:rup_x_preferred":[
         "Sibiu"
@@ -411,7 +417,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882933,
+    "wof:lastmodified":1585864409,
     "wof:name":"Sibiu",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/91/85687691.geojson
+++ b/data/856/876/91/85687691.geojson
@@ -19,6 +19,12 @@
     "label:eng_x_preferred_shortcode":[
         "AR"
     ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Arad"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
+    ],
     "lbl:latitude":46.320335,
     "lbl:longitude":21.742031,
     "lbl:min_zoom":8.0,
@@ -265,7 +271,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882930,
+    "wof:lastmodified":1585864409,
     "wof:name":"Arad",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/97/85687697.geojson
+++ b/data/856/876/97/85687697.geojson
@@ -19,6 +19,12 @@
     "label:eng_x_preferred_shortcode":[
         "AB"
     ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Alba"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
+    ],
     "lbl:latitude":46.142299,
     "lbl:longitude":23.497489,
     "lbl:min_zoom":8.0,
@@ -185,7 +191,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882930,
+    "wof:lastmodified":1585864410,
     "wof:name":"Alba",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/99/85687699.geojson
+++ b/data/856/876/99/85687699.geojson
@@ -19,6 +19,12 @@
     "label:eng_x_preferred_shortcode":[
         "CV"
     ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Covasna"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
+    ],
     "lbl:latitude":45.894848,
     "lbl:longitude":26.106418,
     "lbl:min_zoom":8.0,
@@ -251,7 +257,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882931,
+    "wof:lastmodified":1585864410,
     "wof:name":"Covasna",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/877/05/85687705.geojson
+++ b/data/856/877/05/85687705.geojson
@@ -19,6 +19,12 @@
     "label:eng_x_preferred_shortcode":[
         "VN"
     ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Vrancea"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
+    ],
     "lbl:latitude":45.801319,
     "lbl:longitude":26.938409,
     "lbl:min_zoom":8.0,
@@ -268,7 +274,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882933,
+    "wof:lastmodified":1585864408,
     "wof:name":"Vrancea",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/877/09/85687709.geojson
+++ b/data/856/877/09/85687709.geojson
@@ -11,13 +11,22 @@
     "geom:longitude":27.756072,
     "iso:country":"RO",
     "label:eng_x_preferred_longname":[
-        "Gala\u0163i County"
+        "Galati County"
     ],
     "label:eng_x_preferred_placetype":[
         "county"
     ],
     "label:eng_x_preferred_shortcode":[
         "GL"
+    ],
+    "label:eng_x_variant_longname":[
+        "Gala\u0163i County"
+    ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Gala\u0163i"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
     ],
     "lbl:latitude":45.767069,
     "lbl:longitude":27.765431,
@@ -180,7 +189,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882932,
+    "wof:lastmodified":1585864408,
     "wof:name":"Gala\u0163i",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/877/15/85687715.geojson
+++ b/data/856/877/15/85687715.geojson
@@ -11,13 +11,22 @@
     "geom:longitude":26.771783,
     "iso:country":"RO",
     "label:eng_x_preferred_longname":[
-        "Bac\u0103u County"
+        "Bacau County"
     ],
     "label:eng_x_preferred_placetype":[
         "county"
     ],
     "label:eng_x_preferred_shortcode":[
         "BC"
+    ],
+    "label:eng_x_variant_longname":[
+        "Bac\u0103u County"
+    ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Bac\u0103u"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
     ],
     "lbl:latitude":46.408771,
     "lbl:longitude":26.771729,
@@ -365,7 +374,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882930,
+    "wof:lastmodified":1585864408,
     "wof:name":"Bac\u0103u",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/877/19/85687719.geojson
+++ b/data/856/877/19/85687719.geojson
@@ -11,13 +11,22 @@
     "geom:longitude":24.695537,
     "iso:country":"RO",
     "label:eng_x_preferred_longname":[
-        "Mure\u015f County"
+        "Mures County"
     ],
     "label:eng_x_preferred_placetype":[
         "county"
     ],
     "label:eng_x_preferred_shortcode":[
         "MS"
+    ],
+    "label:eng_x_variant_longname":[
+        "Mure\u015f County"
+    ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Mure\u015f"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
     ],
     "lbl:latitude":46.61552,
     "lbl:longitude":24.7055,
@@ -67,6 +76,9 @@
         "Marusza"
     ],
     "name:ron_x_preferred":[
+        "Mure\u015f"
+    ],
+    "name:ron_x_variant":[
         "Mure\u0219"
     ],
     "name:und_x_variant":[
@@ -189,7 +201,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882932,
+    "wof:lastmodified":1585864408,
     "wof:name":"Mure\u015f",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/877/23/85687723.geojson
+++ b/data/856/877/23/85687723.geojson
@@ -11,13 +11,22 @@
     "geom:longitude":23.105269,
     "iso:country":"RO",
     "label:eng_x_preferred_longname":[
-        "S\u0103laj County"
+        "Salaj County"
     ],
     "label:eng_x_preferred_placetype":[
         "county"
     ],
     "label:eng_x_preferred_shortcode":[
         "SJ"
+    ],
+    "label:eng_x_variant_longname":[
+        "S\u0103laj County"
+    ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul S\u0103laj"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
     ],
     "lbl:latitude":47.124798,
     "lbl:longitude":23.059738,
@@ -163,7 +172,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882933,
+    "wof:lastmodified":1585864408,
     "wof:name":"S\u0103laj",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/877/27/85687727.geojson
+++ b/data/856/877/27/85687727.geojson
@@ -19,6 +19,12 @@
     "label:eng_x_preferred_shortcode":[
         "CJ"
     ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Cluj"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
+    ],
     "lbl:latitude":46.815183,
     "lbl:longitude":23.744517,
     "lbl:min_zoom":8.0,
@@ -159,7 +165,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882931,
+    "wof:lastmodified":1585864408,
     "wof:name":"Cluj",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/877/33/85687733.geojson
+++ b/data/856/877/33/85687733.geojson
@@ -19,6 +19,12 @@
     "label:eng_x_preferred_shortcode":[
         "HR"
     ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Harghita"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
+    ],
     "lbl:latitude":46.546164,
     "lbl:longitude":25.545732,
     "lbl:min_zoom":8.0,
@@ -32,6 +38,9 @@
         "Harghita"
     ],
     "name:ron_x_preferred":[
+        "Harghita"
+    ],
+    "name:ron_x_variant":[
         "Jude\u021bul Harghita"
     ],
     "name:und_x_variant":[
@@ -153,7 +162,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882932,
+    "wof:lastmodified":1585864407,
     "wof:name":"Harghita",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/877/37/85687737.geojson
+++ b/data/856/877/37/85687737.geojson
@@ -19,6 +19,12 @@
     "label:eng_x_preferred_shortcode":[
         "BH"
     ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Bihor"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
+    ],
     "lbl:latitude":47.003809,
     "lbl:longitude":22.162574,
     "lbl:min_zoom":8.0,
@@ -184,7 +190,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882930,
+    "wof:lastmodified":1585864408,
     "wof:name":"Bihor",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/877/43/85687743.geojson
+++ b/data/856/877/43/85687743.geojson
@@ -19,6 +19,12 @@
     "label:eng_x_preferred_shortcode":[
         "VS"
     ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Vaslui"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
+    ],
     "lbl:latitude":46.492615,
     "lbl:longitude":27.77808,
     "lbl:min_zoom":8.0,
@@ -308,7 +314,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882934,
+    "wof:lastmodified":1585864408,
     "wof:name":"Vaslui",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/877/47/85687747.geojson
+++ b/data/856/877/47/85687747.geojson
@@ -11,13 +11,22 @@
     "geom:longitude":26.373242,
     "iso:country":"RO",
     "label:eng_x_preferred_longname":[
-        "Neam\u0163 County"
+        "Neamt County"
     ],
     "label:eng_x_preferred_placetype":[
         "county"
     ],
     "label:eng_x_preferred_shortcode":[
         "NT"
+    ],
+    "label:eng_x_variant_longname":[
+        "Neam\u0163 County"
+    ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Neam\u0163"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
     ],
     "lbl:latitude":46.986698,
     "lbl:longitude":26.358279,
@@ -38,6 +47,9 @@
         "Neam\u0163"
     ],
     "name:ron_x_preferred":[
+        "Neam\u0163"
+    ],
+    "name:ron_x_variant":[
         "Neam\u021b"
     ],
     "name:ukr_x_preferred":[
@@ -163,7 +175,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882933,
+    "wof:lastmodified":1585864409,
     "wof:name":"Neam\u0163",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/877/53/85687753.geojson
+++ b/data/856/877/53/85687753.geojson
@@ -11,13 +11,22 @@
     "geom:longitude":24.520422,
     "iso:country":"RO",
     "label:eng_x_preferred_longname":[
-        "Bistri\u0163a-N\u0103saud County"
+        "Bistrita-Nasaud County"
     ],
     "label:eng_x_preferred_placetype":[
         "county"
     ],
     "label:eng_x_preferred_shortcode":[
         "BN"
+    ],
+    "label:eng_x_variant_longname":[
+        "Bistri\u0163a-N\u0103saud County"
+    ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Bistri\u0163a-N\u0103saud"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
     ],
     "lbl:latitude":47.242454,
     "lbl:longitude":24.472881,
@@ -183,7 +192,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882931,
+    "wof:lastmodified":1585864408,
     "wof:name":"Bistri\u0163a-N\u0103saud",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/877/57/85687757.geojson
+++ b/data/856/877/57/85687757.geojson
@@ -19,6 +19,12 @@
     "label:eng_x_preferred_shortcode":[
         "SM"
     ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Satu Mare"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
+    ],
     "lbl:latitude":47.684356,
     "lbl:longitude":22.897814,
     "lbl:min_zoom":8.0,
@@ -158,10 +164,10 @@
         "Satu Mare"
     ],
     "name:ron_x_preferred":[
-        "Jude\u021bul Satu Mare"
+        "Satu Mare"
     ],
     "name:ron_x_variant":[
-        "Satu Mare"
+        "Jude\u021bul Satu Mare"
     ],
     "name:rus_x_preferred":[
         "\u0421\u0430\u0442\u0443-\u041c\u0430\u0440\u0435"
@@ -350,7 +356,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882933,
+    "wof:lastmodified":1585864407,
     "wof:name":"Satu Mare",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/877/61/85687761.geojson
+++ b/data/856/877/61/85687761.geojson
@@ -19,6 +19,15 @@
     "label:eng_x_preferred_shortcode":[
         "MM"
     ],
+    "label:eng_x_variant_longname":[
+        "Maramure\u015f County"
+    ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Maramure\u015f"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
+    ],
     "lbl:latitude":47.651241,
     "lbl:longitude":23.893186,
     "lbl:min_zoom":8.0,
@@ -136,6 +145,9 @@
         "Maramure\u0219"
     ],
     "name:ron_x_preferred":[
+        "Maramure\u015f"
+    ],
+    "name:ron_x_variant":[
         "Maramure\u0219"
     ],
     "name:rus_x_preferred":[
@@ -301,7 +313,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882932,
+    "wof:lastmodified":1585864407,
     "wof:name":"Maramure\u015f",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/877/69/85687769.geojson
+++ b/data/856/877/69/85687769.geojson
@@ -11,13 +11,22 @@
     "geom:longitude":27.282827,
     "iso:country":"RO",
     "label:eng_x_preferred_longname":[
-        "Ia\u015fi County"
+        "Iasi County"
     ],
     "label:eng_x_preferred_placetype":[
         "county"
     ],
     "label:eng_x_preferred_shortcode":[
         "IS"
+    ],
+    "label:eng_x_variant_longname":[
+        "Ia\u015fi County"
+    ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Ia\u015fi"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
     ],
     "lbl:latitude":47.261265,
     "lbl:longitude":27.338288,
@@ -180,7 +189,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882932,
+    "wof:lastmodified":1585864407,
     "wof:name":"Ia\u015fi",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/877/73/85687773.geojson
+++ b/data/856/877/73/85687773.geojson
@@ -19,6 +19,12 @@
     "label:eng_x_preferred_shortcode":[
         "SV"
     ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Suceava"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
+    ],
     "lbl:latitude":47.62119,
     "lbl:longitude":25.658872,
     "lbl:min_zoom":8.0,
@@ -168,11 +174,11 @@
         "Suceava"
     ],
     "name:ron_x_preferred":[
-        "Jude\u0163ul Suceava"
+        "Suceava"
     ],
     "name:ron_x_variant":[
         "Jude\u021bul Suceava",
-        "Suceava"
+        "Jude\u0163ul Suceava"
     ],
     "name:rus_x_preferred":[
         "\u0421\u0443\u0447\u0430\u0432\u0430"
@@ -352,7 +358,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882933,
+    "wof:lastmodified":1585864408,
     "wof:name":"Suceava",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/877/77/85687777.geojson
+++ b/data/856/877/77/85687777.geojson
@@ -11,13 +11,22 @@
     "geom:longitude":26.761824,
     "iso:country":"RO",
     "label:eng_x_preferred_longname":[
-        "Boto\u015fani County"
+        "Botosani County"
     ],
     "label:eng_x_preferred_placetype":[
         "county"
     ],
     "label:eng_x_preferred_shortcode":[
         "BT"
+    ],
+    "label:eng_x_variant_longname":[
+        "Boto\u015fani County"
+    ],
+    "label:ron_x_preferred_longname":[
+        "Jude\u021bul Boto\u015fani"
+    ],
+    "label:ron_x_preferred_placetype":[
+        "jude\u021bul"
     ],
     "lbl:latitude":47.875264,
     "lbl:longitude":26.77078,
@@ -176,6 +185,9 @@
         "Boto\u0219ani"
     ],
     "name:ron_x_preferred":[
+        "Boto\u015fani"
+    ],
+    "name:ron_x_variant":[
         "Boto\u0219ani"
     ],
     "name:rus_x_preferred":[
@@ -359,7 +371,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1583882931,
+    "wof:lastmodified":1585864408,
     "wof:name":"Boto\u015fani",
     "wof:parent_id":85633745,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1640

This PR:
- Updates `label` and `name` properties for English and Romanian
- Stores variant `label` and `name` values when applicable

No PIP work required, can merge as-is.