### PR TITLE
Update properties of megacities

### DIFF
--- a/data/101/751/949/101751949.geojson
+++ b/data/101/751/949/101751949.geojson
@@ -19,7 +19,7 @@
     "mps:longitude":26.101911,
     "mz:hierarchy_label":1,
     "mz:is_current":1,
-    "mz:min_zoom":12.0,
+    "mz:min_zoom":4.0,
     "name:ace_x_preferred":[
         "Buchar\u00e8st"
     ],
@@ -570,8 +570,11 @@
         85633745
     ],
     "wof:concordances":{
+        "gn:id":683506,
         "gp:id":868274,
-        "qs_pg:id":507232
+        "ne:id":1159151263,
+        "qs_pg:id":507232,
+        "wd:id":"Q19660"
     },
     "wof:coterminous":[
         85687595
@@ -596,7 +599,8 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1607390895,
+    "wof:lastmodified":1608688183,
+    "wof:megacity":1,
     "wof:name":"Bucure\u015fti",
     "wof:parent_id":85687595,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary