### PR TITLE
ro placetype local and more

### DIFF
--- a/data/856/337/45/85633745.geojson
+++ b/data/856/337/45/85633745.geojson
@@ -22,6 +22,9 @@
     "itu:country_code":[
         "40"
     ],
+    "label:eng_x_preferred_placetype":[
+        "country"
+    ],
     "label:eng_x_preferred_shortcode":[
         "RO"
     ],
@@ -1311,7 +1314,7 @@
         "naturalearth",
         "quattroshapes"
     ],
-    "wof:geomhash":"4902732be1df395ef5b0f272d1587faa",
+    "wof:geomhash":"c6c8b680e3559c3a84c5cae72695f442",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -1325,7 +1328,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690857414,
+    "wof:lastmodified":1694492246,
     "wof:name":"Romania",
     "wof:parent_id":102191581,
     "wof:placetype":"country",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2154. Sets placetype local, names, populations, and statoids properties for CARTO