### PR TITLE
ro concordances, placetype local, and more

### DIFF
--- a/data/856/337/45/85633745.geojson
+++ b/data/856/337/45/85633745.geojson
@@ -1293,6 +1293,7 @@
         "hasc:id":"RO",
         "icao:code":"YR",
         "ioc:id":"ROU",
+        "iso:code":"RO",
         "itu:id":"ROU",
         "loc:id":"n79049551",
         "m49:code":"642",
@@ -1307,6 +1308,7 @@
         "wk:page":"Romania",
         "wmo:id":"RO"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"RO",
     "wof:country_alpha3":"ROU",
     "wof:geom_alt":[
@@ -1328,7 +1330,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1694492246,
+    "wof:lastmodified":1695881359,
     "wof:name":"Romania",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/875/81/85687581.geojson
+++ b/data/856/875/81/85687581.geojson
@@ -167,9 +167,15 @@
         "gn:id":679134,
         "gp:id":2346631,
         "hasc:id":"RO.DJ",
+        "iso:code":"RO-DJ",
         "iso:id":"RO-DJ",
+        "qs:local_id":"28",
         "unlc:id":"RO-DJ"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
     "wof:geomhash":"54ea5c285033364d8a46ff158d089f3a",
     "wof:hierarchy":[
@@ -186,7 +192,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1684351668,
+    "wof:lastmodified":1695885311,
     "wof:name":"Dolj",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/875/85/85687585.geojson
+++ b/data/856/875/85/85687585.geojson
@@ -176,9 +176,15 @@
         "gn:id":665283,
         "gp:id":2346648,
         "hasc:id":"RO.TR",
+        "iso:code":"RO-TR",
         "iso:id":"RO-TR",
+        "qs:local_id":"47",
         "unlc:id":"RO-TR"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
     "wof:geomhash":"8b907361c0ef120373fa0f1631d33c63",
     "wof:hierarchy":[
@@ -195,7 +201,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1684351668,
+    "wof:lastmodified":1695885311,
     "wof:name":"Teleorman",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/875/91/85687591.geojson
+++ b/data/856/875/91/85687591.geojson
@@ -357,12 +357,18 @@
         "gn:id":677104,
         "gp:id":2346655,
         "hasc:id":"RO.GR",
+        "iso:code":"RO-GR",
         "iso:id":"RO-GR",
+        "qs:local_id":"30",
         "unlc:id":"RO-GR",
         "wd:id":"Q202351"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
-    "wof:geomhash":"4483f3869b200c5dcc9d0a81551380c5",
+    "wof:geomhash":"5309cd6caaa1b92a24f7191e4b758353",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -377,7 +383,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690857415,
+    "wof:lastmodified":1695885311,
     "wof:name":"Giurgiu",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/875/95/85687595.geojson
+++ b/data/856/875/95/85687595.geojson
@@ -164,9 +164,15 @@
         "gn:id":683504,
         "gp:id":2346624,
         "hasc:id":"RO.BI",
+        "iso:code":"RO-B",
         "iso:id":"RO-B",
+        "qs:local_id":"20",
         "unlc:id":"RO-B"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:coterminous":[
         101751949
     ],
@@ -186,7 +192,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1684351668,
+    "wof:lastmodified":1695885311,
     "wof:name":"Bucure\u015fti",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/875/99/85687599.geojson
+++ b/data/856/875/99/85687599.geojson
@@ -194,9 +194,15 @@
         "gn:id":673612,
         "gp:id":2346639,
         "hasc:id":"RO.MH",
+        "iso:code":"RO-MH",
         "iso:id":"RO-MH",
+        "qs:local_id":"38",
         "unlc:id":"RO-MH"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
     "wof:geomhash":"26d6ee42592036f269341782f77f9501",
     "wof:hierarchy":[
@@ -213,7 +219,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1684351668,
+    "wof:lastmodified":1695885311,
     "wof:name":"Mehedin\u0163i",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/07/85687607.geojson
+++ b/data/856/876/07/85687607.geojson
@@ -309,9 +309,15 @@
         "gn:id":671857,
         "gp:id":2346642,
         "hasc:id":"RO.OT",
+        "iso:code":"RO-OT",
         "iso:id":"RO-OT",
+        "qs:local_id":"41",
         "unlc:id":"RO-OT"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
     "wof:geomhash":"81be90e8142bca71fa37002ed71526c8",
     "wof:hierarchy":[
@@ -328,7 +334,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1684351668,
+    "wof:lastmodified":1695885311,
     "wof:name":"Olt",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/11/85687611.geojson
+++ b/data/856/876/11/85687611.geojson
@@ -263,9 +263,15 @@
         "gn:id":865518,
         "gp:id":29281934,
         "hasc:id":"RO.IF",
+        "iso:code":"RO-IF",
         "iso:id":"RO-IF",
+        "qs:local_id":"36",
         "unlc:id":"RO-IF"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
     "wof:geomhash":"760ab777f303b3c9767588136bfb0e87",
     "wof:hierarchy":[
@@ -282,7 +288,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1684351668,
+    "wof:lastmodified":1695885311,
     "wof:name":"Ilfov",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/15/85687615.geojson
+++ b/data/856/876/15/85687615.geojson
@@ -372,12 +372,18 @@
         "gn:id":683016,
         "gp:id":2346654,
         "hasc:id":"RO.CL",
+        "iso:code":"RO-CL",
         "iso:id":"RO-CL",
+        "qs:local_id":"22",
         "unlc:id":"RO-CL",
         "wd:id":"Q212561"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
-    "wof:geomhash":"389b7c5af720170f7323bed75cf20746",
+    "wof:geomhash":"e61cf18866ec05fada3a1b77d5dfc1dc",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -392,7 +398,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690857420,
+    "wof:lastmodified":1695885312,
     "wof:name":"C\u0103l\u0103ra\u015fi",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/19/85687619.geojson
+++ b/data/856/876/19/85687619.geojson
@@ -167,9 +167,15 @@
         "gn:id":676898,
         "gp:id":2346633,
         "hasc:id":"RO.GJ",
+        "iso:code":"RO-GJ",
         "iso:id":"RO-GJ",
+        "qs:local_id":"31",
         "unlc:id":"RO-GJ"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
     "wof:geomhash":"8e66d7d2c4eeac15dab3f89ecd91804f",
     "wof:hierarchy":[
@@ -186,7 +192,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1684351668,
+    "wof:lastmodified":1695885312,
     "wof:name":"Gorj",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/21/85687621.geojson
+++ b/data/856/876/21/85687621.geojson
@@ -192,9 +192,15 @@
         "gn:id":675848,
         "gp:id":2346636,
         "hasc:id":"RO.IL",
+        "iso:code":"RO-IL",
         "iso:id":"RO-IL",
+        "qs:local_id":"34",
         "unlc:id":"RO-IL"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
     "wof:geomhash":"230c93d0ee748db111d35bb47b56bf4a",
     "wof:hierarchy":[
@@ -211,7 +217,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1684351668,
+    "wof:lastmodified":1695885312,
     "wof:name":"Ialomi\u0163a",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/27/85687627.geojson
+++ b/data/856/876/27/85687627.geojson
@@ -194,9 +194,15 @@
         "gn:id":682714,
         "gp:id":2346626,
         "hasc:id":"RO.CS",
+        "iso:code":"RO-CS",
         "iso:id":"RO-CS",
+        "qs:local_id":"23",
         "unlc:id":"RO-CS"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
     "wof:geomhash":"28006ff956cb020f6e54cfefb67fcbe0",
     "wof:hierarchy":[
@@ -213,7 +219,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1684351668,
+    "wof:lastmodified":1695885312,
     "wof:name":"Cara\u015f-Severin",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/33/85687633.geojson
+++ b/data/856/876/33/85687633.geojson
@@ -498,11 +498,17 @@
         "gn:id":680962,
         "gp:id":2346628,
         "hasc:id":"RO.CT",
+        "iso:code":"RO-CT",
         "iso:id":"RO-CT",
+        "qs:local_id":"25",
         "wd:id":"Q79808"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
-    "wof:geomhash":"d428bc2ac613288f53f8f31fc05555e6",
+    "wof:geomhash":"5550bde86aa74ed39749b21dfc57c7bc",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -517,7 +523,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690857418,
+    "wof:lastmodified":1695885312,
     "wof:name":"Constan\u0163a",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/37/85687637.geojson
+++ b/data/856/876/37/85687637.geojson
@@ -191,8 +191,14 @@
         "gn:id":679385,
         "gp:id":2346630,
         "hasc:id":"RO.DB",
-        "iso:id":"RO-DB"
+        "iso:code":"RO-DB",
+        "iso:id":"RO-DB",
+        "qs:local_id":"27"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
     "wof:geomhash":"9cbaa423cd88d11e7e071e566a0c5265",
     "wof:hierarchy":[
@@ -209,7 +215,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1684351668,
+    "wof:lastmodified":1695885312,
     "wof:name":"D\u00e2mbovi\u0163a",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/43/85687643.geojson
+++ b/data/856/876/43/85687643.geojson
@@ -194,9 +194,15 @@
         "gn:id":662892,
         "gp:id":2346652,
         "hasc:id":"RO.VL",
+        "iso:code":"RO-VL",
         "iso:id":"RO-VL",
+        "qs:local_id":"51",
         "unlc:id":"RO-VL"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
     "wof:geomhash":"804d012579663cb1ae0e6147303275ff",
     "wof:hierarchy":[
@@ -213,7 +219,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1684351668,
+    "wof:lastmodified":1695885312,
     "wof:name":"V\u00e2lcea",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/45/85687645.geojson
+++ b/data/856/876/45/85687645.geojson
@@ -195,9 +195,15 @@
         "gn:id":686192,
         "gp:id":2346617,
         "hasc:id":"RO.AG",
+        "iso:code":"RO-AG",
         "iso:id":"RO-AG",
+        "qs:local_id":"13",
         "unlc:id":"RO-AG"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
     "wof:geomhash":"dc01f10f49d70b5ca03df60554c7e792",
     "wof:hierarchy":[
@@ -214,7 +220,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1684351668,
+    "wof:lastmodified":1695885312,
     "wof:name":"Arge\u015f",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/55/85687655.geojson
+++ b/data/856/876/55/85687655.geojson
@@ -199,9 +199,15 @@
         "gn:id":665091,
         "gp:id":2346649,
         "hasc:id":"RO.TM",
+        "iso:code":"RO-TM",
         "iso:id":"RO-TM",
+        "qs:local_id":"48",
         "unlc:id":"RO-TM"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
     "wof:geomhash":"c13b8c6e822f7e2445beeb752fef95eb",
     "wof:hierarchy":[
@@ -218,7 +224,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1684351668,
+    "wof:lastmodified":1695885312,
     "wof:name":"Timi\u015f",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/61/85687661.geojson
+++ b/data/856/876/61/85687661.geojson
@@ -288,9 +288,15 @@
         "gn:id":669737,
         "gp:id":2346643,
         "hasc:id":"RO.PH",
+        "iso:code":"RO-PH",
         "iso:id":"RO-PH",
+        "qs:local_id":"42",
         "unlc:id":"RO-PH"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
     "wof:geomhash":"f19f7121ef4efa96049c66cf0dcfddb0",
     "wof:hierarchy":[
@@ -307,7 +313,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1684351669,
+    "wof:lastmodified":1695885312,
     "wof:name":"Prahova",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/63/85687663.geojson
+++ b/data/856/876/63/85687663.geojson
@@ -420,12 +420,18 @@
         "gn:id":683901,
         "gp:id":2346622,
         "hasc:id":"RO.BR",
+        "iso:code":"RO-BR",
         "iso:id":"RO-BR",
+        "qs:local_id":"18",
         "unlc:id":"RO-BR",
         "wd:id":"Q188478"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
-    "wof:geomhash":"cc997c24253c81a34cb6c1bced3bcd34",
+    "wof:geomhash":"9111af9f347af9e3e1a6fb4e6c146812",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -440,7 +446,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690857419,
+    "wof:lastmodified":1695885312,
     "wof:name":"Br\u0103ila",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/67/85687667.geojson
+++ b/data/856/876/67/85687667.geojson
@@ -387,12 +387,18 @@
         "gn:id":683121,
         "gp:id":2346625,
         "hasc:id":"RO.BZ",
+        "iso:code":"RO-BZ",
         "iso:id":"RO-BZ",
+        "qs:local_id":"21",
         "unlc:id":"RO-BZ",
         "wd:id":"Q201404"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
-    "wof:geomhash":"116464820db0bbb9c98355b800b441a2",
+    "wof:geomhash":"c191ab52fcd05b815010bfeefc80d0d4",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -407,7 +413,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690857417,
+    "wof:lastmodified":1695885312,
     "wof:name":"Buz\u0103u",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/71/85687671.geojson
+++ b/data/856/876/71/85687671.geojson
@@ -339,12 +339,18 @@
         "gn:id":675917,
         "gp:id":2346635,
         "hasc:id":"RO.HD",
+        "iso:code":"RO-HD",
         "iso:id":"RO-HD",
+        "qs:local_id":"33",
         "unlc:id":"RO-HD",
         "wd:id":"Q215719"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
-    "wof:geomhash":"42c04276b99b6bb96519d37ab7cff909",
+    "wof:geomhash":"6b2bf3568db5d7c616dae80d60700f99",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -359,7 +365,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690857421,
+    "wof:lastmodified":1695885312,
     "wof:name":"Hunedoara",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/79/85687679.geojson
+++ b/data/856/876/79/85687679.geojson
@@ -404,11 +404,17 @@
         "gn:id":664517,
         "gp:id":2346650,
         "hasc:id":"RO.TL",
+        "iso:code":"RO-TL",
         "iso:id":"RO-TL",
+        "qs:local_id":"49",
         "wd:id":"Q11585"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
-    "wof:geomhash":"c14e6222734914eb343c88063bbaace4",
+    "wof:geomhash":"c79a0af51b07eef12507f5a26b981c2b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -423,7 +429,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690857420,
+    "wof:lastmodified":1695885313,
     "wof:name":"Tulcea",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/83/85687683.geojson
+++ b/data/856/876/83/85687683.geojson
@@ -472,12 +472,18 @@
         "gn:id":683843,
         "gp:id":2346623,
         "hasc:id":"RO.BV",
+        "iso:code":"RO-BV",
         "iso:id":"RO-BV",
+        "qs:local_id":"19",
         "unlc:id":"RO-BV",
         "wd:id":"Q82174"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
-    "wof:geomhash":"bf4e012f3cab1033e352d1f4ce476e85",
+    "wof:geomhash":"038f2ab514fc6faeb00befb76d8433fc",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -492,7 +498,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690857420,
+    "wof:lastmodified":1695885313,
     "wof:name":"Bra\u015fov",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/87/85687687.geojson
+++ b/data/856/876/87/85687687.geojson
@@ -454,12 +454,18 @@
         "gn:id":667267,
         "gp:id":2346646,
         "hasc:id":"RO.SB",
+        "iso:code":"RO-SB",
         "iso:id":"RO-SB",
+        "qs:local_id":"45",
         "unlc:id":"RO-SB",
         "wd:id":"Q83324"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
-    "wof:geomhash":"2680b79935009d3f812b28ef9c011118",
+    "wof:geomhash":"dcbf0bf58acf2d6ca6bd23c35f205872",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -474,7 +480,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690857418,
+    "wof:lastmodified":1695885313,
     "wof:name":"Sibiu",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/91/85687691.geojson
+++ b/data/856/876/91/85687691.geojson
@@ -276,9 +276,15 @@
         "gn:id":686253,
         "gp:id":2346616,
         "hasc:id":"RO.AR",
+        "iso:code":"RO-AR",
         "iso:id":"RO-AR",
+        "qs:local_id":"12",
         "unlc:id":"RO-AR"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
     "wof:geomhash":"7007e40cbbcb6200879af43f804b6430",
     "wof:hierarchy":[
@@ -295,7 +301,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1684351669,
+    "wof:lastmodified":1695885313,
     "wof:name":"Arad",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/97/85687697.geojson
+++ b/data/856/876/97/85687697.geojson
@@ -213,12 +213,18 @@
         "gn:id":686581,
         "gp:id":2346615,
         "hasc:id":"RO.AB",
+        "iso:code":"RO-AB",
         "iso:id":"RO-AB",
+        "qs:local_id":"11",
         "unlc:id":"RO-AB",
         "wd:id":"Q13361651"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
-    "wof:geomhash":"3043cb84f8eceb323b80a92493f61516",
+    "wof:geomhash":"9a1daf0182820edcf476a6872a72ab5a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -233,7 +239,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690857419,
+    "wof:lastmodified":1695885313,
     "wof:name":"Alba",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/876/99/85687699.geojson
+++ b/data/856/876/99/85687699.geojson
@@ -288,12 +288,18 @@
         "gn:id":680428,
         "gp:id":2346629,
         "hasc:id":"RO.CV",
+        "iso:code":"RO-CV",
         "iso:id":"RO-CV",
+        "qs:local_id":"26",
         "unlc:id":"RO-CV",
         "wd:id":"Q837157"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
-    "wof:geomhash":"bb622ff95d66f1c9fc2c4cdc2e71d8f5",
+    "wof:geomhash":"4b527aeba4191ca41eee795e5ff7a020",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -308,7 +314,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690857419,
+    "wof:lastmodified":1695885313,
     "wof:name":"Covasna",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/877/05/85687705.geojson
+++ b/data/856/877/05/85687705.geojson
@@ -276,9 +276,15 @@
         "gn:id":662447,
         "gp:id":2346653,
         "hasc:id":"RO.VN",
+        "iso:code":"RO-VN",
         "iso:id":"RO-VN",
+        "qs:local_id":"52",
         "unlc:id":"RO-VN"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
     "wof:geomhash":"5c51fc5b92d5cce863e670f395e43568",
     "wof:hierarchy":[
@@ -295,7 +301,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1684351669,
+    "wof:lastmodified":1695885313,
     "wof:name":"Vrancea",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/877/09/85687709.geojson
+++ b/data/856/877/09/85687709.geojson
@@ -194,9 +194,15 @@
         "gn:id":677692,
         "gp:id":2346632,
         "hasc:id":"RO.GL",
+        "iso:code":"RO-GL",
         "iso:id":"RO-GL",
+        "qs:local_id":"29",
         "unlc:id":"RO-GL"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
     "wof:geomhash":"839e04f43e27a1213c6d94024403c416",
     "wof:hierarchy":[
@@ -213,7 +219,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1684351669,
+    "wof:lastmodified":1695885313,
     "wof:name":"Gala\u0163i",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/877/15/85687715.geojson
+++ b/data/856/877/15/85687715.geojson
@@ -423,12 +423,18 @@
         "gn:id":685947,
         "gp:id":2346618,
         "hasc:id":"RO.BC",
+        "iso:code":"RO-BC",
         "iso:id":"RO-BC",
+        "qs:local_id":"14",
         "unlc:id":"RO-BC",
         "wd:id":"Q182679"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
-    "wof:geomhash":"b5df4b6cd068987c84a7af26d60d698a",
+    "wof:geomhash":"841e2221e490e45ebaa2544702ebba82",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -443,7 +449,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690857417,
+    "wof:lastmodified":1695885313,
     "wof:name":"Bac\u0103u",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/877/19/85687719.geojson
+++ b/data/856/877/19/85687719.geojson
@@ -200,9 +200,15 @@
         "gn:id":672628,
         "gp:id":2346640,
         "hasc:id":"RO.MS",
+        "iso:code":"RO-MS",
         "iso:id":"RO-MS",
+        "qs:local_id":"39",
         "unlc:id":"RO-MS"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
     "wof:geomhash":"f2510546be924a375539f3f5f033fa3b",
     "wof:hierarchy":[
@@ -219,7 +225,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1684351670,
+    "wof:lastmodified":1695885313,
     "wof:name":"Mure\u015f",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/877/23/85687723.geojson
+++ b/data/856/877/23/85687723.geojson
@@ -174,9 +174,15 @@
         "gn:id":668248,
         "gp:id":2346644,
         "hasc:id":"RO.SJ",
+        "iso:code":"RO-SJ",
         "iso:id":"RO-SJ",
+        "qs:local_id":"43",
         "unlc:id":"RO-SJ"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
     "wof:geomhash":"d98f1107285262096766c91c660c873b",
     "wof:hierarchy":[
@@ -193,7 +199,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1684351670,
+    "wof:lastmodified":1695885313,
     "wof:name":"S\u0103laj",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/877/27/85687727.geojson
+++ b/data/856/877/27/85687727.geojson
@@ -168,9 +168,15 @@
         "gn:id":681291,
         "gp:id":2346627,
         "hasc:id":"RO.CJ",
+        "iso:code":"RO-CJ",
         "iso:id":"RO-CJ",
+        "qs:local_id":"24",
         "unlc:id":"RO-CJ"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
     "wof:geomhash":"e89ea45f1869c902b2db04200726b653",
     "wof:hierarchy":[
@@ -187,7 +193,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1684351670,
+    "wof:lastmodified":1695885314,
     "wof:name":"Cluj",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/877/33/85687733.geojson
+++ b/data/856/877/33/85687733.geojson
@@ -170,9 +170,15 @@
         "gn:id":676309,
         "gp:id":2346634,
         "hasc:id":"RO.HR",
+        "iso:code":"RO-HR",
         "iso:id":"RO-HR",
+        "qs:local_id":"32",
         "unlc:id":"RO-HR"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
     "wof:geomhash":"14799b974c44505e27d429e510ba57da",
     "wof:hierarchy":[
@@ -189,7 +195,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1684351670,
+    "wof:lastmodified":1695885314,
     "wof:name":"Harghita",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/877/37/85687737.geojson
+++ b/data/856/877/37/85687737.geojson
@@ -195,9 +195,15 @@
         "gn:id":684878,
         "gp:id":2346619,
         "hasc:id":"RO.BH",
+        "iso:code":"RO-BH",
         "iso:id":"RO-BH",
+        "qs:local_id":"15",
         "unlc:id":"RO-BH"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
     "wof:geomhash":"95eb49cc1439207b55491aa5c4cf2740",
     "wof:hierarchy":[
@@ -214,7 +220,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1684351670,
+    "wof:lastmodified":1695885314,
     "wof:name":"Bihor",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/877/43/85687743.geojson
+++ b/data/856/877/43/85687743.geojson
@@ -360,12 +360,18 @@
         "gn:id":663116,
         "gp:id":2346651,
         "hasc:id":"RO.VS",
+        "iso:code":"RO-VS",
         "iso:id":"RO-VS",
+        "qs:local_id":"50",
         "unlc:id":"RO-VS",
         "wd:id":"Q192269"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
-    "wof:geomhash":"c09bff693e8c0a7dba3cd56355be375d",
+    "wof:geomhash":"4223c2b09edb8123228495acd3322bf6",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -380,7 +386,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690857416,
+    "wof:lastmodified":1695885314,
     "wof:name":"Vaslui",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/877/47/85687747.geojson
+++ b/data/856/877/47/85687747.geojson
@@ -180,9 +180,15 @@
         "gn:id":672460,
         "gp:id":2346641,
         "hasc:id":"RO.NT",
+        "iso:code":"RO-NT",
         "iso:id":"RO-NT",
+        "qs:local_id":"40",
         "unlc:id":"RO-NT"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
     "wof:geomhash":"cf58105148a0c5637b20b5a9d56a1a4d",
     "wof:hierarchy":[
@@ -199,7 +205,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1684351670,
+    "wof:lastmodified":1695885314,
     "wof:name":"Neam\u0163",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/877/53/85687753.geojson
+++ b/data/856/877/53/85687753.geojson
@@ -197,9 +197,15 @@
         "gn:id":684647,
         "gp:id":2346620,
         "hasc:id":"RO.BN",
+        "iso:code":"RO-BN",
         "iso:id":"RO-BN",
+        "qs:local_id":"16",
         "unlc:id":"RO-BN"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
     "wof:geomhash":"00133a7e4ed167033626f29916f939ab",
     "wof:hierarchy":[
@@ -216,7 +222,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1684351670,
+    "wof:lastmodified":1695885314,
     "wof:name":"Bistri\u0163a-N\u0103saud",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/877/57/85687757.geojson
+++ b/data/856/877/57/85687757.geojson
@@ -408,12 +408,18 @@
         "gn:id":667869,
         "gp:id":2346645,
         "hasc:id":"RO.SM",
+        "iso:code":"RO-SM",
         "iso:id":"RO-SM",
+        "qs:local_id":"44",
         "unlc:id":"RO-SM",
         "wd:id":"Q185332"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
-    "wof:geomhash":"8a6f7ad7d97d724671f64e6ba402fac1",
+    "wof:geomhash":"6dec3f0d85a4ce5a9d12ad880d7cf4e1",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -428,7 +434,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690857415,
+    "wof:lastmodified":1695885314,
     "wof:name":"Satu Mare",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/877/61/85687761.geojson
+++ b/data/856/877/61/85687761.geojson
@@ -326,12 +326,18 @@
         "gn:id":673887,
         "gp:id":2346638,
         "hasc:id":"RO.MM",
+        "iso:code":"RO-MM",
         "iso:id":"RO-MM",
+        "qs:local_id":"37",
         "unlc:id":"RO-MM",
         "wd:id":"Q10975458"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
-    "wof:geomhash":"1e9f9ec7a964ae6e259c93d5b542d665",
+    "wof:geomhash":"68231291a2a2b4c148bbaee5d32e1370",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -346,7 +352,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690857415,
+    "wof:lastmodified":1695885314,
     "wof:name":"Maramure\u015f",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/877/69/85687769.geojson
+++ b/data/856/877/69/85687769.geojson
@@ -194,9 +194,15 @@
         "gn:id":675809,
         "gp:id":2346637,
         "hasc:id":"RO.IS",
+        "iso:code":"RO-IS",
         "iso:id":"RO-IS",
+        "qs:local_id":"35",
         "unlc:id":"RO-IS"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
     "wof:geomhash":"a95e5ba67d45da5bb1c5a0aa95c052f3",
     "wof:hierarchy":[
@@ -213,7 +219,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1684351670,
+    "wof:lastmodified":1695885314,
     "wof:name":"Ia\u015fi",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/877/73/85687773.geojson
+++ b/data/856/877/73/85687773.geojson
@@ -380,12 +380,18 @@
         "gn:id":665849,
         "gp:id":2346647,
         "hasc:id":"RO.SV",
+        "iso:code":"RO-SV",
         "iso:id":"RO-SV",
+        "qs:local_id":"46",
         "unlc:id":"RO-SV",
         "wd:id":"Q46400"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
-    "wof:geomhash":"e79b3b8e5d4aeb29f15b1da161da4a4e",
+    "wof:geomhash":"4ae386c211114a05304d5b061078c192",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -400,7 +406,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690857416,
+    "wof:lastmodified":1695885315,
     "wof:name":"Suceava",
     "wof:parent_id":85633745,
     "wof:placetype":"region",

--- a/data/856/877/77/85687777.geojson
+++ b/data/856/877/77/85687777.geojson
@@ -420,12 +420,18 @@
         "gn:id":684038,
         "gp:id":2346621,
         "hasc:id":"RO.BT",
+        "iso:code":"RO-BT",
         "iso:id":"RO-BT",
+        "qs:local_id":"17",
         "unlc:id":"RO-BT",
         "wd:id":"Q178855"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RO",
-    "wof:geomhash":"ab4cd313699e329eb9dd40c58e941974",
+    "wof:geomhash":"198032ed650fe3fb8731bd669cde8a46",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -440,7 +446,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690857417,
+    "wof:lastmodified":1695885315,
     "wof:name":"Boto\u015fani",
     "wof:parent_id":85633745,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.